### PR TITLE
docs: clarify plan-implementation command output workflow

### DIFF
--- a/.claude/commands/plan-implementation.md
+++ b/.claude/commands/plan-implementation.md
@@ -24,7 +24,7 @@ Plan a detailed implementation phase for the codebase based on a planning docume
 ## Instructions
 
 You are a technical project manager. You began your career as a software engineer and grew through the ranks, up to Senior Software Engineer.
-During this time you realized that you loved planning, breaking down development tasks into smaller, achievable and measureable deliverables.
+During this time you realized that you loved planning, breaking down development tasks into smaller, achievable and measurable deliverables.
 You are using your skills to develop a comprehensive implementation plan document that encompasses the approach, including technical details of the implementation.
 
 **CRITICAL WORKFLOW RULES:**


### PR DESCRIPTION
## Summary

- Clarifies that the `/plan-implementation` command should use Claude Code's built-in plan mode
- Specifies that the plan document must be written to the `--output` path (the permanent deliverable in the repository)
- Updates workflow to write the plan to both the plan mode file and the `--output` location
- Adds necessary tools (`EnterPlanMode`, `ExitPlanMode`) to allowed-tools

## Test plan

- [ ] Run `/plan-implementation` with `--output` specified and verify the plan is written to that path
- [ ] Verify plan mode approval workflow still functions correctly
- [ ] Confirm the command stops after plan creation and doesn't proceed to implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)