### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alvincrespo/hashnode-content-converter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alvincrespo/hashnode-content-converter",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alvincrespo/hashnode-content-converter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Convert Hashnode blog exports to framework-agnostic Markdown with YAML frontmatter",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps version to 0.2.1 for documentation site release

## After Merge
After merging, create the release tag to trigger documentation deployment:
```bash
git tag v0.2.1
git push origin v0.2.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)