### PR TITLE
chore: release v0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alvincrespo/hashnode-content-converter",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alvincrespo/hashnode-content-converter",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alvincrespo/hashnode-content-converter",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Convert Hashnode blog exports to framework-agnostic Markdown with YAML frontmatter",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps version to 0.2.2 for npm publish (0.2.1 was already published)

## Release Notes
This is a version bump only - no code changes since v0.2.1. The documentation site changes from PR #67 are included in this release.

## After Merge
After this PR is merged:
1. Create and push tag: `git tag v0.2.2 && git push origin v0.2.2`
2. The release workflow will publish to npm
3. The docs workflow will deploy to GitHub Pages (requires environment configuration - see note below)

**Note**: Before the docs workflow can deploy, the `github-pages` environment needs to be configured to allow `v*` tag deployments in repository Settings > Environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)