### PR TITLE
fix: update release command to reflect automated tagging

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -48,13 +48,15 @@ If there are uncommitted changes, stop and ask the user to commit or stash them 
    - **Type**: <patch|minor|major>
 
    ## After Merge
-   Once this PR is merged, run \`/release tag\` to create and push the release tag."
+   Once this PR is merged, the release tag will be created automatically and the package will be published to npm.
+
+   To skip automatic tagging, add \`[SKIP RELEASE]\` to the PR title."
    ```
 10. Tell the user the PR has been created and they should wait for checks to pass and merge
 
-### Phase 2: Create Release Tag (after PR is merged)
+### Phase 2: Create Release Tag (only if [SKIP RELEASE] was used)
 
-If the user runs `/release tag`:
+If the user runs `/release tag` (only needed when auto-tagging was skipped):
 
 1. Run `git fetch origin && git checkout main && git pull` to get the merged changes
 2. Read the version from package.json
@@ -66,11 +68,13 @@ If the user runs `/release tag`:
 
 After Phase 1, tell the user:
 - The PR URL
+- The new version number
 - To wait for CI checks to pass
 - To merge the PR
-- To run `/release tag` after merging to trigger the release
+- That after merge, tagging and npm publishing will happen automatically
+- They can monitor progress at: https://github.com/alvincrespo/hashnode-content-converter/actions
 
-After Phase 2, tell the user:
+After Phase 2 (manual tagging), tell the user:
 - The tag that was created
 - That the GitHub Actions release workflow has been triggered
 - They can monitor progress at: https://github.com/alvincrespo/hashnode-content-converter/actions/workflows/release.yml

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: main
+          fetch-depth: 0
 
       - name: Extract version and create tag
         run: |

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -20,26 +20,39 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - name: Extract version and create tag
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Validate version matches branch
         env:
           GITHUB_HEAD_REF: ${{ github.head_ref }}
         run: |
-          VERSION=$(node -p "require('./package.json').version")
-          TAG="v$VERSION"
+          TAG="v${{ steps.version.outputs.version }}"
           BRANCH_VERSION="${GITHUB_HEAD_REF#release/}"
-
           if [ "$TAG" != "$BRANCH_VERSION" ]; then
-            echo "Version mismatch: package.json has $TAG but branch is $BRANCH_VERSION"
+            echo "::error::Version mismatch: package.json has $TAG but branch is $BRANCH_VERSION"
             exit 1
           fi
 
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists, skipping"
-            exit 0
+      - name: Check if tag exists
+        id: tag_check
+        run: |
+          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Tag ${{ steps.version.outputs.tag }} already exists, skipping"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
-          echo "Creating tag $TAG"
+      - name: Create and push tag
+        if: steps.tag_check.outputs.exists == 'false'
+        run: |
+          echo "Creating tag ${{ steps.version.outputs.tag }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "$TAG"
-          git push origin "$TAG"
+          git tag "${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -1,3 +1,12 @@
+# Auto Tag Release
+#
+# Automatically creates and pushes a git tag when a release PR is merged.
+#
+# References:
+# - GitHub Context: https://docs.github.com/en/actions/reference/contexts#github-context
+# - Pull Request Events: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+# - PR Webhook Payload: https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request
+
 name: Auto Tag Release
 
 on:

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -23,8 +23,15 @@ jobs:
       - name: Extract version and create tag
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          echo "Creating tag v$VERSION"
+          TAG="v$VERSION"
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping"
+            exit 0
+          fi
+
+          echo "Creating tag $TAG"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "v$VERSION"
-          git push origin "v$VERSION"
+          git tag "$TAG"
+          git push origin "$TAG"

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -21,9 +21,17 @@ jobs:
           fetch-depth: 0
 
       - name: Extract version and create tag
+        env:
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
           TAG="v$VERSION"
+          BRANCH_VERSION="${GITHUB_HEAD_REF#release/}"
+
+          if [ "$TAG" != "$BRANCH_VERSION" ]; then
+            echo "Version mismatch: package.json has $TAG but branch is $BRANCH_VERSION"
+            exit 1
+          fi
 
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "Tag $TAG already exists, skipping"

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -29,10 +29,10 @@ jobs:
 
       - name: Validate version matches branch
         env:
-          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           TAG="v${{ steps.version.outputs.version }}"
-          BRANCH_VERSION="${GITHUB_HEAD_REF#release/}"
+          BRANCH_VERSION="${HEAD_REF#release/}"
           if [ "$TAG" != "$BRANCH_VERSION" ]; then
             echo "::error::Version mismatch: package.json has $TAG but branch is $BRANCH_VERSION"
             exit 1


### PR DESCRIPTION
## Summary
- Updates `/release` command documentation to reflect that tagging is now automatic
- Improves `auto-tag-release.yml` workflow with better structure and error handling

## Changes

### Release Command (`.claude/commands/release.md`)
- PR body template now states tagging happens automatically after merge
- Phase 2 clarified as only needed when `[SKIP RELEASE]` was used
- Output section updated to mention automatic tagging and publishing

### Auto-Tag Workflow (`.github/workflows/auto-tag-release.yml`)
Refactored into separate steps for better debugging in GitHub Actions UI:

1. **Extract version** - Reads version from package.json, outputs `version` and `tag`
2. **Validate version matches branch** - Fails with `::error::` if `release/v1.2.3` branch doesn't match `1.2.3` in package.json
3. **Check if tag exists** - Skips gracefully if tag already exists (handles race conditions)
4. **Create and push tag** - Only runs if tag doesn't exist (via `if:` condition)

Additional improvements:
- Added `fetch-depth: 0` to ensure full git history is available
- Uses `$GITHUB_OUTPUT` for step outputs (modern GitHub Actions syntax)
- Uses `::error::` annotation for better error visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)