### PR TITLE
feat: add flat output mode for static site generator compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
+    # Run CI on all pull requests regardless of target branch
+    # This ensures sub-branches merged into feature branches are tested
 
 jobs:
   test:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,57 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+
+            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+
+            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'
+

--- a/README.md
+++ b/README.md
@@ -5,13 +5,31 @@
 
 Convert Hashnode blog exports to framework-agnostic Markdown with YAML frontmatter. This TypeScript package transforms your Hashnode content into portable Markdown files with proper frontmatter, localized images, and cleaned formatting—ready for any static site generator or blog platform.
 
-> **Status**: Production-ready with 99.36% test coverage. All core components, CLI, and programmatic API are complete.
+> **Status**: Production-ready with 99.5% test coverage (484 tests). All core components, CLI, and programmatic API are complete.
+
+## Table of Contents
+
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [CLI](#cli)
+  - [Output Modes](#output-modes)
+  - [Programmatic API](#programmatic-api)
+- [Current Status](#current-status)
+- [Architecture](#architecture)
+- [Development](#development)
+- [Releasing](#releasing)
+- [Migrating from convert-hashnode.js](#migrating-from-convert-hashnodejs)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [License](#license)
 
 ## Features
 
 - **Metadata Extraction**: Parse Hashnode exports and extract essential post metadata (title, slug, dates, tags, cover image)
 - **Markdown Transformation**: Clean Hashnode-specific formatting quirks (align attributes, trailing whitespace)
 - **Image Localization**: Download CDN images and replace URLs with local paths
+- **Flat Output Mode**: Optional `--flat` flag creates `{slug}.md` files with shared image folder, ideal for Bridgetown, Jekyll, and Hugo
 - **Intelligent Retry**: Marker-based strategy to skip already-downloaded images and permanent failures
 - **YAML Frontmatter**: Generate framework-agnostic frontmatter from post metadata
 - **Atomic File Operations**: Safe, atomic writes with directory traversal protection
@@ -63,10 +81,76 @@ npx @alvincrespo/hashnode-content-converter convert \
 | `--no-skip-existing` | | Overwrite existing posts | |
 | `--verbose` | `-v` | Show detailed output including image downloads | `false` |
 | `--quiet` | `-q` | Suppress all output except errors | `false` |
+| `--flat` | `-f` | Use flat output mode (`{slug}.md` instead of `{slug}/index.md`) | `false` |
+| `--image-folder <name>` | | Image folder name (flat mode only) | `_images` |
+| `--image-prefix <prefix>` | | Image path prefix in markdown (flat mode only) | `/images` |
 
 **Exit Codes**:
 - `0` - Conversion completed successfully
 - `1` - Conversion completed with errors, or validation failed
+
+### Output Modes
+
+The converter supports two output modes for organizing posts and images.
+
+#### Nested Mode (Default)
+
+Each post gets its own directory with images alongside:
+
+```
+output/
+├── my-first-post/
+│   ├── index.md          # Image refs: ./image.png
+│   └── image.png
+├── my-second-post/
+│   ├── index.md
+│   └── screenshot.png
+```
+
+#### Flat Mode (`--flat`)
+
+Standalone `.md` files with images in a shared sibling folder. The image folder (`_images/` by default) is created as a sibling of the output directory — for example, if `--output` is `./src/_posts`, images go to `./src/_images/`.
+
+```bash
+npx @alvincrespo/hashnode-content-converter convert \
+  --export ./export.json \
+  --output ./src/_posts \
+  --flat
+```
+
+```
+src/
+├── _posts/          ← output directory (--output)
+│   ├── my-first-post.md      # Image refs: /images/image.png
+│   └── my-second-post.md
+└── _images/         ← sibling image folder
+    ├── image.png
+    └── screenshot.png
+```
+
+> **Note**: The default image folder name (`_images`) and path prefix (`/images`) are intentionally different. The folder name is the directory created on disk; the prefix is the URL path used in markdown image references. Configure your web server or static site generator to serve `_images/` at `/images`, or use `--image-folder` and `--image-prefix` to align them.
+
+Customize the image folder and path prefix for your framework:
+
+```bash
+# Hugo-style assets
+npx @alvincrespo/hashnode-content-converter convert \
+  --export ./export.json \
+  --output ./content/posts \
+  --flat \
+  --image-folder assets \
+  --image-prefix /assets
+```
+
+#### When to Use Each Mode
+
+| Criteria | Nested (default) | Flat (`--flat`) |
+|----------|-------------------|-----------------|
+| **Best for** | Self-contained posts | Bridgetown, Jekyll, Hugo, Next.js |
+| **Post files** | `{slug}/index.md` | `{slug}.md` |
+| **Image location** | Per-post directory | Shared sibling folder |
+| **Image paths** | Relative (`./image.png`) | Absolute (`/images/image.png`) |
+| **Image deduplication** | No (per-post copies) | Yes (shared folder) |
 
 ### Programmatic API
 
@@ -80,6 +164,45 @@ import { Converter } from '@alvincrespo/hashnode-content-converter';
 // One-liner conversion
 const result = await Converter.fromExportFile('./export.json', './blog');
 console.log(`Converted ${result.converted} posts in ${result.duration}`);
+```
+
+#### Flat Mode
+
+Configure flat output mode at the instance level via `ConverterConfig`:
+
+```typescript
+import { Converter } from '@alvincrespo/hashnode-content-converter';
+
+// Flat mode with default settings (_images folder, /images prefix)
+const converter = new Converter({
+  config: {
+    outputStructure: { mode: 'flat' },
+  },
+});
+const result = await converter.convertAllPosts('./export.json', './src/_posts');
+
+// Flat mode with custom image settings (e.g., for Hugo)
+const hugoConverter = new Converter({
+  config: {
+    outputStructure: {
+      mode: 'flat',
+      imageFolderName: 'assets',
+      imagePathPrefix: '/assets',
+    },
+  },
+});
+await hugoConverter.convertAllPosts('./export.json', './content/posts');
+```
+
+Or use the static factory method:
+
+```typescript
+const result = await Converter.fromExportFile(
+  './export.json',
+  './src/_posts',
+  { skipExisting: true },                    // ConversionOptions
+  { outputStructure: { mode: 'flat' } }      // ConverterConfig
+);
 ```
 
 #### With Progress Tracking
@@ -346,7 +469,7 @@ If you're migrating from the original `convert-hashnode.js` script, here are the
 |-----------------|--------------|
 | Environment variables (`EXPORT_DIR`, `READ_DIR`) | CLI arguments (`--export`, `--output`) |
 | Hardcoded paths | User-specified paths |
-| Single output format | Same output format, more control |
+| Single output format | Nested (default) or flat mode (`--flat`) |
 
 ### Migration Steps
 
@@ -366,10 +489,11 @@ If you're migrating from the original `convert-hashnode.js` script, here are the
      --output ./blog
    ```
 
-3. **Output format**: The generated Markdown files maintain the same structure:
+3. **Output format**: The generated Markdown files maintain the same structure by default:
    - YAML frontmatter with title, date, description, cover image
    - Cleaned markdown content (align attributes removed)
-   - Downloaded images in post directories
+   - Downloaded images in post directories (nested mode, default)
+   - Or use `--flat` for standalone `.md` files with shared image folder (see [Output Modes](#output-modes))
 
 ### Programmatic Migration
 

--- a/docs/IMPLEMENTATION_FLAT.md
+++ b/docs/IMPLEMENTATION_FLAT.md
@@ -675,12 +675,14 @@ private recordDownloadFailureForDir(
 ```
 
 #### Step 3.2: Write ImageProcessor Unit Tests
-- [ ] Test `processWithContext` uses provided `imageDir`
-- [ ] Test `processWithContext` uses provided `imagePathPrefix`
-- [ ] Test marker files created in shared directory
-- [ ] Test path prefix with trailing slash
-- [ ] Test path prefix without trailing slash
-- [ ] Test existing `process()` method unchanged
+- [x] Test `processWithContext` uses provided `imageDir` (Written in Step 3.1)
+- [x] Test `processWithContext` uses provided `imagePathPrefix` (Written in Step 3.1)
+- [x] Test marker files created in shared directory (Written in Step 3.1)
+- [x] Test path prefix with trailing slash (Written in Step 3.1)
+- [x] Test path prefix without trailing slash (Written in Step 3.1)
+- [x] Test existing `process()` method unchanged (Written in Step 3.1)
+
+**Status**: ✅ COMPLETE - All tests were written during Step 3.1 implementation (78 tests, 99.46% coverage)
 
 **Test Cases for `tests/unit/processors/image-processor.test.ts`:**
 

--- a/docs/IMPLEMENTATION_FLAT.md
+++ b/docs/IMPLEMENTATION_FLAT.md
@@ -1136,7 +1136,7 @@ if (!options.quiet) {
 - [ ] Test `--flat` defaults to `false`
 - [ ] Test `--image-folder` option passed through
 - [ ] Test `--image-prefix` option passed through
-- [ ] Test validation: `--image-folder` without `--flat` (should warn or be ignored)
+- [ ] Test validation: `--image-folder` without `--flat` (should warn and continue)
 
 **Test Cases for `tests/unit/cli/cli.test.ts`:**
 

--- a/docs/IMPLEMENTATION_FLAT.md
+++ b/docs/IMPLEMENTATION_FLAT.md
@@ -346,9 +346,9 @@ constructor(config?: FileWriterConfig) {
 ```
 
 #### Step 2.2: Update postExists Method
-- [ ] Check for `{slug}.md` file in flat mode
-- [ ] Check for `{slug}/` directory in nested mode (current behavior)
-- [ ] Add unit tests for flat mode existence check
+- [x] Check for `{slug}.md` file in flat mode
+- [x] Check for `{slug}/` directory in nested mode (current behavior)
+- [x] Add unit tests for flat mode existence check
 
 **Proposed Changes to `postExists` method (lines 183-192):**
 

--- a/docs/IMPLEMENTATION_FLAT.md
+++ b/docs/IMPLEMENTATION_FLAT.md
@@ -978,8 +978,8 @@ describe('Flat Output Mode', () => {
 ```
 
 #### Step 4.4: Document ImageProcessor Instance Independence
-- [ ] Enhance `ImageProcessor` class JSDoc to explain instance independence
-- [ ] Add comment in `Converter.convertPost()` at the `downloadOptions` check
+- [x] Enhance `ImageProcessor` class JSDoc to explain instance independence
+- [x] Converter already has adequate documentation (no changes needed)
 
 **Why this matters:** The marker-based download state is persisted on disk, not in-memory. This means multiple `ImageProcessor` instances safely share state, but this isn't obvious when reading the code.
 

--- a/docs/IMPLEMENTATION_FLAT.md
+++ b/docs/IMPLEMENTATION_FLAT.md
@@ -215,9 +215,9 @@ src/
 ### Phase 1: Type Definitions
 
 #### Step 1.1: Add OutputStructure Interface
-- [ ] Create `OutputStructure` interface in `src/types/converter-options.ts`
-- [ ] Add `outputStructure` field to `ConversionOptions` interface
-- [ ] Export new types from `src/index.ts`
+- [x] Create `OutputStructure` interface in `src/types/converter-options.ts`
+- [x] Add `outputStructure` field to `ConverterConfig` interface
+- [x] Export new types from `src/index.ts`
 
 **Proposed Changes to `src/types/converter-options.ts`:**
 
@@ -273,8 +273,8 @@ export interface ConversionOptions {
 ```
 
 #### Step 1.2: Add ImageProcessorContext Interface
-- [ ] Create `ImageProcessorContext` interface in `src/types/image-processor.ts`
-- [ ] Export from `src/index.ts`
+- [x] Create `ImageProcessorContext` interface in `src/types/image-processor.ts`
+- [x] Export from `src/index.ts`
 
 **New File: `src/types/image-processor.ts`:**
 
@@ -378,10 +378,10 @@ postExists(outputDir: string, slug: string): boolean {
 ```
 
 #### Step 2.3: Update writePost Method
-- [ ] Write to `{slug}.md` in flat mode
-- [ ] Write to `{slug}/index.md` in nested mode (current behavior)
-- [ ] Ensure output directory exists (but don't create subdirectory in flat mode)
-- [ ] Add unit tests for flat mode file writing
+- [x] Write to `{slug}.md` in flat mode
+- [x] Write to `{slug}/index.md` in nested mode (current behavior)
+- [x] Ensure output directory exists (but don't create subdirectory in flat mode)
+- [x] Add unit tests for flat mode file writing
 
 **Proposed Changes to `writePost` method (lines 203-244):**
 
@@ -762,11 +762,11 @@ describe('processWithContext', () => {
 ### Phase 4: Converter Updates
 
 #### Step 4.1: Update convertPost Method
-- [ ] Read `outputStructure` from options
-- [ ] Calculate image directory based on mode (nested vs flat)
-- [ ] Create image directory before processing
-- [ ] Use `processWithContext()` for flat mode
-- [ ] Create FileWriter with appropriate `outputMode`
+- [x] Read `outputStructure` from options
+- [x] Calculate image directory based on mode (nested vs flat)
+- [x] Create image directory before processing
+- [x] Use `processWithContext()` for flat mode
+- [x] Create FileWriter with appropriate `outputMode`
 
 **Proposed Changes to `src/converter.ts` `convertPost` method (around line 375-455):**
 

--- a/docs/IMPLEMENTATION_FLAT.md
+++ b/docs/IMPLEMENTATION_FLAT.md
@@ -870,8 +870,8 @@ async convertPost(
 ```
 
 #### Step 4.2: Update convertAllPosts Method
-- [ ] Create FileWriter with correct output mode for `postExists` check
-- [ ] Ensure image directory created once at start (for flat mode)
+- [x] Create FileWriter with correct output mode for `postExists` check (Already complete - uses `this.fileWriter`)
+- [x] Fix skip event `outputPath` to use mode-aware path (Bug fix completed)
 
 **Proposed Changes to `src/converter.ts` `convertAllPosts` method (around line 274):**
 

--- a/docs/IMPLEMENTATION_FLAT.md
+++ b/docs/IMPLEMENTATION_FLAT.md
@@ -902,13 +902,13 @@ if (effectiveOptions.skipExisting && existenceChecker.postExists(outputDir, slug
 ```
 
 #### Step 4.3: Write Converter Integration Tests
-- [ ] Test full pipeline in flat mode
-- [ ] Test image directory creation as sibling
-- [ ] Test image path prefix in output markdown
-- [ ] Test post existence check with flat files
-- [ ] Test custom `imageFolderName` option
-- [ ] Test custom `imagePathPrefix` option
-- [ ] Test nested mode unchanged (regression)
+- [x] Test full pipeline in flat mode
+- [x] Test image directory creation as sibling
+- [x] Test image path prefix in output markdown
+- [x] Test post existence check with flat files
+- [x] Test custom `imageFolderName` option
+- [x] Test custom `imagePathPrefix` option
+- [x] Test nested mode unchanged (regression)
 
 **Test Cases for `tests/integration/converter.test.ts`:**
 

--- a/docs/IMPLEMENTATION_FLAT.md
+++ b/docs/IMPLEMENTATION_FLAT.md
@@ -1018,8 +1018,8 @@ const imageProcessor = options?.downloadOptions
 
 #### Step 5.1: Update CLIOptions Interface
 - [ ] Add `flat` boolean flag
-- [ ] Add `imageFolderName` optional string (renamed from `imageFolder`)
-- [ ] Add `imagePathPrefix` optional string (renamed from `imagePrefix`)
+- [ ] Add `imageFolder` optional string
+- [ ] Add `imagePrefix` optional string
 
 **Proposed Changes to `src/cli/convert.ts`:**
 

--- a/docs/IMPLEMENTATION_FLAT.md
+++ b/docs/IMPLEMENTATION_FLAT.md
@@ -311,9 +311,9 @@ export interface ImageProcessorContext {
 ### Phase 2: FileWriter Service Updates
 
 #### Step 2.1: Add outputMode Configuration
-- [ ] Add `outputMode` to `FileWriterConfig` interface
-- [ ] Store output mode in class property
-- [ ] Update constructor to accept new config
+- [x] Add `outputMode` to `FileWriterConfig` interface
+- [x] Store output mode in class property
+- [x] Update constructor to accept new config
 
 **Proposed Changes to `src/services/file-writer.ts`:**
 

--- a/docs/IMPLEMENTATION_FLAT.md
+++ b/docs/IMPLEMENTATION_FLAT.md
@@ -516,10 +516,10 @@ describe('Flat Output Mode', () => {
 ### Phase 3: ImageProcessor Updates
 
 #### Step 3.1: Add processWithContext Method
-- [ ] Create new `processWithContext()` method that accepts `ImageProcessorContext`
-- [ ] Use provided `imageDir` for downloads instead of inferring from blogDir
-- [ ] Use provided `imagePathPrefix` for markdown URL replacement
-- [ ] Keep existing `process()` method for backwards compatibility
+- [x] Create new `processWithContext()` method that accepts `ImageProcessorContext`
+- [x] Use provided `imageDir` for downloads instead of inferring from blogDir
+- [x] Use provided `imagePathPrefix` for markdown URL replacement
+- [x] Keep existing `process()` method for backwards compatibility
 
 **Proposed Changes to `src/processors/image-processor.ts`:**
 

--- a/docs/IMPLEMENTATION_FLAT.md
+++ b/docs/IMPLEMENTATION_FLAT.md
@@ -1067,6 +1067,7 @@ program
 #### Step 5.3: Build outputStructure from CLI Options
 - [ ] Create `OutputStructure` object when `--flat` is set
 - [ ] Pass through to `ConversionOptions`
+- [ ] Warn if `--image-folder` or `--image-prefix` are used without `--flat`
 
 **Proposed Changes to `runConvert` function (around lines 268-279):**
 
@@ -1075,6 +1076,16 @@ program
 const conversionOptions: ConversionOptions = {
   skipExisting: options.skipExisting,
 };
+
+// Warn if flat-mode-only options are used without --flat
+if (!options.flat) {
+  if (options.imageFolder) {
+    console.warn('Warning: --image-folder is ignored without --flat');
+  }
+  if (options.imagePrefix) {
+    console.warn('Warning: --image-prefix is ignored without --flat');
+  }
+}
 
 // Add output structure config if flat mode is enabled
 if (options.flat) {
@@ -1165,6 +1176,41 @@ describe('--image-prefix option', () => {
       '--flat', '--image-prefix', '/static/images'
     ]);
     expect(options.imagePrefix).toBe('/static/images');
+  });
+});
+
+describe('flat mode options without --flat', () => {
+  it('should warn when --image-folder is used without --flat', async () => {
+    const consoleSpy = vi.spyOn(console, 'warn');
+    await runConvert({
+      export: 'export.json',
+      output: 'out',
+      flat: false,
+      imageFolder: 'assets',  // Provided without --flat
+      // ...other required options
+    });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('--image-folder is ignored without --flat')
+    );
+  });
+
+  it('should warn when --image-prefix is used without --flat', async () => {
+    const consoleSpy = vi.spyOn(console, 'warn');
+    await runConvert({
+      export: 'export.json',
+      output: 'out',
+      flat: false,
+      imagePrefix: '/assets',  // Provided without --flat
+      // ...other required options
+    });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('--image-prefix is ignored without --flat')
+    );
+  });
+
+  it('should not build outputStructure when flat is false', async () => {
+    // Even if imageFolder/imagePrefix are provided, they should be ignored
+    // and outputStructure should not be set
   });
 });
 ```

--- a/docs/IMPLEMENTATION_FLAT.md
+++ b/docs/IMPLEMENTATION_FLAT.md
@@ -207,7 +207,6 @@ src/
 | Marker location | `{imageDir}/.downloaded-markers/` (per-post) | `{imageDir}/.downloaded-markers/` (shared) |
 
 > **Note on markers**: Both modes use `{imageDir}/.downloaded-markers/` for download state. In nested mode, each post has its own markers directory. In flat mode, all posts share a single markers directory, enabling cross-post image deduplication.
-| Marker location | `{slug}/.downloaded-markers/` | `_images/.downloaded-markers/` |
 
 ---
 

--- a/docs/IMPLEMENTATION_FLAT.md
+++ b/docs/IMPLEMENTATION_FLAT.md
@@ -458,11 +458,11 @@ async writePost(
 ```
 
 #### Step 2.4: Write FileWriter Unit Tests
-- [ ] Test `postExists()` returns true when `{slug}.md` exists in flat mode
-- [ ] Test `postExists()` returns false when `{slug}.md` does not exist in flat mode
-- [ ] Test `writePost()` creates `{slug}.md` in flat mode (no subdirectory)
-- [ ] Test `writePost()` creates output directory if missing in flat mode
-- [ ] Test nested mode behavior remains unchanged
+- [x] Test `postExists()` returns true when `{slug}.md` exists in flat mode
+- [x] Test `postExists()` returns false when `{slug}.md` does not exist in flat mode
+- [x] Test `writePost()` creates `{slug}.md` in flat mode (no subdirectory)
+- [x] Test `writePost()` creates output directory if missing in flat mode
+- [x] Test nested mode behavior remains unchanged
 
 **Test Cases for `tests/unit/services/file-writer.test.ts`:**
 

--- a/docs/IMPLEMENTATION_FLAT.md
+++ b/docs/IMPLEMENTATION_FLAT.md
@@ -1477,10 +1477,10 @@ export type { ImageProcessorContext } from './types/image-processor';
 ```
 
 #### Step 6.2: Update README
-- [ ] Add flat mode to CLI options table
-- [ ] Add flat mode usage example
-- [ ] Document `--image-folder` and `--image-prefix` options
-- [ ] Add library usage example with `outputStructure`
+- [x] Add flat mode to CLI options table
+- [x] Add flat mode usage example
+- [x] Document `--image-folder` and `--image-prefix` options
+- [x] Add library usage example with `outputStructure`
 
 #### Step 6.3: Update CHANGELOG
 - [ ] Document new feature in Unreleased/next version section

--- a/docs/IMPLEMENTATION_FLAT.md
+++ b/docs/IMPLEMENTATION_FLAT.md
@@ -1240,8 +1240,8 @@ validateImagePrefix('/');              // Too short - rejected
 ```
 
 #### Step 5.4: Update Startup Display
-- [ ] Show output mode (nested/flat) in startup info
-- [ ] Show image folder name when in flat mode
+- [x] Show output mode (nested/flat) in startup info
+- [x] Show image folder name when in flat mode
 
 **Proposed Changes to startup display (around lines 256-265):**
 

--- a/docs/IMPLEMENTATION_FLAT.md
+++ b/docs/IMPLEMENTATION_FLAT.md
@@ -255,14 +255,12 @@ export interface OutputStructure {
 }
 ```
 
-**Proposed Changes to `ConversionOptions` interface:**
+**Proposed Changes to `ConverterConfig` interface:**
+
+> **Note**: `outputStructure` is an instance-level concern (determines file naming and image storage for the lifetime of a Converter), so it belongs on `ConverterConfig` rather than the runtime `ConversionOptions`.
 
 ```typescript
-export interface ConversionOptions {
-  skipExisting?: boolean;
-  downloadOptions?: ImageDownloadOptions;
-  loggerConfig?: LoggerConfig;
-
+export interface ConverterConfig {
   /**
    * Output structure configuration.
    * Controls file naming and image storage location.
@@ -1069,7 +1067,7 @@ program
 - [ ] Add validation functions for imageFolder and imagePrefix (security)
 - [ ] Create `OutputStructure` object when `--flat` is set
 - [ ] Validate imageFolder and imagePrefix before use
-- [ ] Pass through to `ConversionOptions`
+- [ ] Pass through to `ConverterConfig` via `ConverterDependencies`
 - [ ] Warn if `--image-folder` or `--image-prefix` are used without `--flat`
 
 **Security Note**: This step includes path validation to prevent directory traversal attacks and injection vulnerabilities.
@@ -1155,12 +1153,9 @@ function validateImagePrefix(prefix: string): void {
 
 **Proposed Changes to `runConvert` function (around lines 268-279):**
 
-```typescript
-// Build conversion options
-const conversionOptions: ConversionOptions = {
-  skipExisting: options.skipExisting,
-};
+> **Note**: `outputStructure` is passed via `ConverterDependencies.config` (instance-level), not `ConversionOptions` (runtime). The Converter reads it at construction time.
 
+```typescript
 // Warn if flat-mode-only options are used without --flat
 if (!options.flat) {
   if (options.imageFolder) {
@@ -1171,7 +1166,8 @@ if (!options.flat) {
   }
 }
 
-// Add output structure config if flat mode is enabled
+// Build converter dependencies with output structure config
+let converterDeps: ConverterDependencies | undefined;
 if (options.flat) {
   // Validate user-provided values for security
   if (options.imageFolder) {
@@ -1181,12 +1177,21 @@ if (options.flat) {
     validateImagePrefix(options.imagePrefix);
   }
 
-  conversionOptions.outputStructure = {
-    mode: 'flat',
-    imageFolderName: options.imageFolder,   // undefined uses default
-    imagePathPrefix: options.imagePrefix,   // undefined uses default
+  converterDeps = {
+    config: {
+      outputStructure: {
+        mode: 'flat',
+        imageFolderName: options.imageFolder,   // undefined uses default '_images'
+        imagePathPrefix: options.imagePrefix,    // undefined uses default '/images'
+      },
+    },
   };
 }
+
+// Build conversion options (runtime settings)
+const conversionOptions: ConversionOptions = {
+  skipExisting: options.skipExisting,
+};
 
 // Add logger config if log file specified
 if (logFilePath) {
@@ -1196,6 +1201,10 @@ if (logFilePath) {
   };
   conversionOptions.loggerConfig = loggerConfig;
 }
+
+// Create converter with progress callback and optional flat mode config
+const progressCallback = createProgressCallback(options.quiet, options.verbose);
+const converter = Converter.withProgress(progressCallback, converterDeps);
 ```
 
 **Security Considerations**:

--- a/docs/IMPLEMENTATION_FLAT.md
+++ b/docs/IMPLEMENTATION_FLAT.md
@@ -1465,8 +1465,8 @@ describe('Security integration tests', () => {
 ### Phase 6: Exports and Documentation
 
 #### Step 6.1: Update Public Exports
-- [ ] Export `OutputStructure` type from `src/index.ts`
-- [ ] Export `ImageProcessorContext` type from `src/index.ts`
+- [x] Export `OutputStructure` type from `src/index.ts`
+- [x] Export `ImageProcessorContext` type from `src/index.ts`
 
 **Proposed Changes to `src/index.ts`:**
 

--- a/docs/IMPLEMENTATION_FLAT.md
+++ b/docs/IMPLEMENTATION_FLAT.md
@@ -1064,11 +1064,11 @@ program
 ```
 
 #### Step 5.3: Build outputStructure from CLI Options
-- [ ] Add validation functions for imageFolder and imagePrefix (security)
-- [ ] Create `OutputStructure` object when `--flat` is set
-- [ ] Validate imageFolder and imagePrefix before use
-- [ ] Pass through to `ConverterConfig` via `ConverterDependencies`
-- [ ] Warn if `--image-folder` or `--image-prefix` are used without `--flat`
+- [x] Add validation functions for imageFolder and imagePrefix (security)
+- [x] Create `OutputStructure` object when `--flat` is set
+- [x] Validate imageFolder and imagePrefix before use
+- [x] Pass through to `ConverterConfig` via `ConverterDependencies`
+- [x] Warn if `--image-folder` or `--image-prefix` are used without `--flat`
 
 **Security Note**: This step includes path validation to prevent directory traversal attacks and injection vulnerabilities.
 

--- a/docs/IMPLEMENTATION_FLAT.md
+++ b/docs/IMPLEMENTATION_FLAT.md
@@ -1018,9 +1018,9 @@ const imageProcessor = options?.downloadOptions
 ### Phase 5: CLI Updates
 
 #### Step 5.1: Update CLIOptions Interface
-- [ ] Add `flat` boolean flag
-- [ ] Add `imageFolder` optional string
-- [ ] Add `imagePrefix` optional string
+- [x] Add `flat` boolean flag
+- [x] Add `imageFolder` optional string
+- [x] Add `imagePrefix` optional string
 
 **Proposed Changes to `src/cli/convert.ts`:**
 

--- a/docs/IMPLEMENTATION_FLAT.md
+++ b/docs/IMPLEMENTATION_FLAT.md
@@ -1266,20 +1266,20 @@ if (!options.quiet) {
 ```
 
 #### Step 5.5: Write CLI Unit Tests
-- [ ] Test `--flat` flag sets `flat: true`
-- [ ] Test `--flat` defaults to `false`
-- [ ] Test `--image-folder` option passed through
-- [ ] Test `--image-prefix` option passed through
-- [ ] Test validation: `--image-folder` without `--flat` (should warn and continue)
-- [ ] Test validateImageFolder rejects absolute paths
-- [ ] Test validateImageFolder rejects path traversal (..)
-- [ ] Test validateImageFolder rejects shell metacharacters
-- [ ] Test validateImageFolder accepts valid folder names
-- [ ] Test validateImagePrefix rejects paths without leading /
-- [ ] Test validateImagePrefix rejects XSS characters
-- [ ] Test validateImagePrefix accepts valid prefixes
+- [x] Test `--flat` flag sets `flat: true`
+- [x] Test `--flat` defaults to `false`
+- [x] Test `--image-folder` option passed through
+- [x] Test `--image-prefix` option passed through
+- [x] Test validation: `--image-folder` without `--flat` (should warn and continue)
+- [x] Test validateImageFolder rejects absolute paths
+- [x] Test validateImageFolder rejects path traversal (..)
+- [x] Test validateImageFolder rejects shell metacharacters
+- [x] Test validateImageFolder accepts valid folder names
+- [x] Test validateImagePrefix rejects paths without leading /
+- [x] Test validateImagePrefix rejects XSS characters
+- [x] Test validateImagePrefix accepts valid prefixes
 
-**Test Cases for `tests/unit/cli/cli.test.ts`:**
+**Test Cases for `tests/unit/cli.test.ts`:**
 
 ```typescript
 describe('--flat flag', () => {
@@ -1497,7 +1497,7 @@ export type { ImageProcessorContext } from './types/image-processor';
 |-----------|-----------|-------|
 | FileWriter | `tests/unit/services/file-writer.test.ts` | ~8 new tests |
 | ImageProcessor | `tests/unit/processors/image-processor.test.ts` | ~10 new tests |
-| CLI | `tests/unit/cli/cli.test.ts` | ~6 new tests |
+| CLI | `tests/unit/cli.test.ts` | ~6 new tests |
 
 ### Integration Tests to Add
 

--- a/docs/IMPLEMENTATION_FLAT.md
+++ b/docs/IMPLEMENTATION_FLAT.md
@@ -1040,10 +1040,10 @@ interface CLIOptions {
 ```
 
 #### Step 5.2: Add CLI Flags
-- [ ] Add `-f, --flat` boolean flag
-- [ ] Add `--image-folder <name>` option
-- [ ] Add `--image-prefix <prefix>` option
-- [ ] Update help text
+- [x] Add `-f, --flat` boolean flag
+- [x] Add `--image-folder <name>` option
+- [x] Add `--image-prefix <prefix>` option
+- [x] Update help text
 
 **Proposed Changes to CLI setup (around lines 325-336):**
 

--- a/docs/features/flat/PHASE_1_STEP_1_1.md
+++ b/docs/features/flat/PHASE_1_STEP_1_1.md
@@ -1,0 +1,298 @@
+# Phase 1.1: Add OutputStructure Interface - Implementation Plan
+
+**Issue**: [#43 - 1.1 Add OutputStructure Interface](https://github.com/alvincrespo/hashnode-content-converter/issues/43)
+**Status**: COMPLETED
+**Date**: 2025-12-29
+**Completed**: 2026-01-12
+**Phase**: Phase 1: Type Definitions (Step 1.1)
+**PR**: [#72](https://github.com/alvincrespo/hashnode-content-converter/pull/72)
+
+---
+
+## Overview
+
+Add the `OutputStructure` interface to support configurable output modes (nested vs flat) for the conversion process. This is a foundational type definition that will be used by subsequent phases to implement flat output mode functionality.
+
+**Scope**:
+- IN: Type definitions only (`OutputStructure` interface, `ConversionOptions` update, exports)
+- OUT: No implementation code, no tests (type definitions are verified via TypeScript compilation)
+
+**Reference**: [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) (lines 216-273)
+
+---
+
+## Requirements Summary
+
+From GitHub Issue #43 and IMPLEMENTATION_FLAT.md:
+
+- Create `OutputStructure` interface with:
+  - `mode: 'nested' | 'flat'` - determines file organization
+  - `imageFolderName?: string` - shared image folder name (flat mode)
+  - `imagePathPrefix?: string` - path prefix for image references (flat mode)
+- Add `outputStructure?: OutputStructure` field to `ConversionOptions`
+- Export new types from `src/index.ts`
+
+**Key Requirements**:
+- Type-safe implementation (no `any` types)
+- Full JSDoc documentation matching existing patterns
+- Backwards compatible (new field is optional)
+
+---
+
+## Architecture Design
+
+### 1. Interface Design
+
+#### OutputStructure Interface
+
+```typescript
+/**
+ * Output structure configuration for the conversion process.
+ * Controls how posts and images are organized on disk.
+ */
+export interface OutputStructure {
+  /**
+   * Output mode determines file organization:
+   * - 'nested': Creates {slug}/index.md with images in same directory (default)
+   * - 'flat': Creates {slug}.md with images in shared sibling directory
+   * @default 'nested'
+   */
+  mode: 'nested' | 'flat';
+
+  /**
+   * Name of the shared image folder (flat mode only).
+   * Created as a sibling to the output directory.
+   * @default '_images'
+   * @example 'assets' -> creates {output}/../assets/
+   */
+  imageFolderName?: string;
+
+  /**
+   * Path prefix for image references in markdown (flat mode only).
+   * Should match your static site generator's asset path configuration.
+   * @default '/images'
+   * @example '/assets/images' -> ![alt](/assets/images/filename.png)
+   */
+  imagePathPrefix?: string;
+}
+```
+
+### 2. Design Patterns
+
+Following existing patterns from `converter-options.ts`:
+- Interface-based configuration (like `ImageDownloadOptions`, `LoggerConfig`)
+- Optional fields with JSDoc `@default` annotations
+- Clear separation between required and optional properties
+- Comprehensive JSDoc with examples
+
+---
+
+## Implementation Steps
+
+### Step 1: Add OutputStructure Interface
+
+**File**: [src/types/converter-options.ts](../../../src/types/converter-options.ts)
+
+**Action**: Add the `OutputStructure` interface after `LoggerConfig` (around line 45)
+
+**Implementation**:
+
+```typescript
+// Add after LoggerConfig interface (line 45)
+
+/**
+ * Output structure configuration for the conversion process.
+ * Controls how posts and images are organized on disk.
+ */
+export interface OutputStructure {
+  /**
+   * Output mode determines file organization:
+   * - 'nested': Creates {slug}/index.md with images in same directory (default)
+   * - 'flat': Creates {slug}.md with images in shared sibling directory
+   * @default 'nested'
+   */
+  mode: 'nested' | 'flat';
+
+  /**
+   * Name of the shared image folder (flat mode only).
+   * Created as a sibling to the output directory.
+   * @default '_images'
+   * @example 'assets' -> creates {output}/../assets/
+   */
+  imageFolderName?: string;
+
+  /**
+   * Path prefix for image references in markdown (flat mode only).
+   * Should match your static site generator's asset path configuration.
+   * @default '/images'
+   * @example '/assets/images' -> ![alt](/assets/images/filename.png)
+   */
+  imagePathPrefix?: string;
+}
+```
+
+### Step 2: Update ConversionOptions Interface
+
+**File**: [src/types/converter-options.ts](../../../src/types/converter-options.ts)
+
+**Action**: Add `outputStructure` field to `ConversionOptions` interface
+
+**Implementation**:
+
+```typescript
+// Update ConversionOptions interface (around line 50-68)
+export interface ConversionOptions {
+  /**
+   * Skip posts that already exist in the output directory.
+   * When true, posts with existing directories are skipped.
+   * When false, conversion will attempt to overwrite.
+   * @default true
+   */
+  skipExisting?: boolean;
+
+  /**
+   * Image download configuration options.
+   */
+  downloadOptions?: ImageDownloadOptions;
+
+  /**
+   * Logger configuration options.
+   */
+  loggerConfig?: LoggerConfig;
+
+  /**
+   * Output structure configuration.
+   * Controls file naming and image storage location.
+   * @default { mode: 'nested' }
+   */
+  outputStructure?: OutputStructure;
+}
+```
+
+### Step 3: Verify Exports
+
+**File**: [src/index.ts](../../../src/index.ts)
+
+**Action**: Verify `OutputStructure` is exported via existing wildcard export
+
+**Note**: The existing `export * from './types/converter-options'` (line 42) will automatically export the new `OutputStructure` interface. No changes needed to `src/index.ts`.
+
+---
+
+## Testing Strategy
+
+### Type Definition Verification
+
+For pure type definitions, verification is done through:
+
+1. **TypeScript Compilation**: `npm run type-check` will verify:
+   - Interface syntax is correct
+   - No circular dependencies
+   - Types are properly exported
+
+2. **Build Verification**: `npm run build` will verify:
+   - Types are emitted to `dist/`
+   - Declaration files (.d.ts) are generated correctly
+
+### No Unit Tests Required
+
+Type definitions don't require unit tests because:
+- TypeScript compiler validates syntax and type correctness
+- Interfaces have no runtime behavior to test
+- Usage will be tested in subsequent phases (Phase 2-5)
+
+---
+
+## Integration Points
+
+### 1. Upstream (Input)
+- **Source**: CLI (`src/cli/convert.ts`) and library users
+- **Input**: Will be populated from CLI flags or direct API calls
+- **Integration**: CLI will build `OutputStructure` from `--flat`, `--image-folder`, `--image-prefix` flags (Phase 5)
+
+### 2. Downstream (Output)
+- **Consumers**:
+  - `Converter` (Phase 4) - uses `outputStructure` to determine behavior
+  - `FileWriter` (Phase 2) - uses `mode` for file naming
+  - `ImageProcessor` (Phase 3) - uses `imageFolderName` and `imagePathPrefix`
+
+---
+
+## Success Criteria
+
+### Functional Requirements
+- [x] `OutputStructure` interface exists with `mode`, `imageFolderName`, `imagePathPrefix`
+- [x] `ConversionOptions` includes optional `outputStructure` field
+- [x] Types are exported from package entry point
+
+### Non-Functional Requirements
+- [x] No `any` types
+- [x] JSDoc documentation on all fields with @default and @example
+- [x] TypeScript compilation passes
+- [x] Build succeeds
+
+---
+
+## Verification Checklist
+
+### Post-Implementation
+
+```bash
+# Verify TypeScript compilation
+npm run type-check
+# Expected: No TypeScript errors
+
+# Verify build succeeds
+npm run build
+# Expected: dist/ directory created with type declarations
+
+# Verify export (optional manual check)
+# Check dist/types/converter-options.d.ts contains OutputStructure
+```
+
+---
+
+## Implementation Checklist
+
+- [x] Add `OutputStructure` interface to `src/types/converter-options.ts`
+- [x] Add `outputStructure` field to `ConversionOptions` interface
+- [x] Run `npm run type-check` - verify no errors
+- [x] Run `npm run build` - verify success
+- [x] Update GitHub issue #43 status (closes via PR #72)
+
+---
+
+## Files to Modify
+
+| File | Action |
+|------|--------|
+| [src/types/converter-options.ts](../../../src/types/converter-options.ts) | Add `OutputStructure` interface, update `ConversionOptions` |
+| [src/index.ts](../../../src/index.ts) | No changes needed (wildcard export handles it) |
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Type conflicts with existing code | Low | Low | Types are additive, no existing code uses `outputStructure` |
+| Breaking downstream consumers | Low | Low | Field is optional, maintains backwards compatibility |
+
+---
+
+## Summary
+
+**Phase 1.1** will deliver the foundational `OutputStructure` type definition that:
+- Defines the configuration structure for nested vs flat output modes
+- Extends `ConversionOptions` with optional `outputStructure` field
+- Maintains backwards compatibility (new field is optional, defaults to nested mode)
+- Follows existing codebase patterns for type definitions
+
+This is a low-risk, type-only change that enables subsequent implementation phases.
+
+---
+
+## Next Steps After Implementation
+
+1. Proceed to Phase 1.2: Add ImageProcessorContext Interface
+2. Update GitHub issue #43 to mark tasks complete

--- a/docs/features/flat/PHASE_1_STEP_1_2.md
+++ b/docs/features/flat/PHASE_1_STEP_1_2.md
@@ -1,0 +1,272 @@
+# Phase 1.2: Add ImageProcessorContext Interface - Implementation Plan
+
+**Issue**: [#44 - 1.2 Add ImageProcessorContext Interface](https://github.com/alvincrespo/hashnode-content-converter/issues/44)
+**Status**: ✅ COMPLETED
+**Date**: 2026-01-12
+**Completed**: 2026-01-12
+**Phase**: Phase 1: Type Definitions (Step 1.2)
+**PR**: [#74](https://github.com/alvincrespo/hashnode-content-converter/pull/74)
+
+---
+
+## Overview
+
+Add the `ImageProcessorContext` interface to enable the ImageProcessor to work with flat output mode. This interface provides the necessary context (image directory, path prefix, marker directory) for processing images when the output structure differs from the default nested mode.
+
+**Scope**:
+- IN: Type definitions only (`ImageProcessorContext` interface, exports update)
+- OUT: No implementation code, no tests (type definitions are verified via TypeScript compilation)
+
+**Reference**: [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) (lines 275-307)
+
+---
+
+## Requirements Summary
+
+From GitHub Issue #44 and IMPLEMENTATION_FLAT.md:
+
+- Create `ImageProcessorContext` interface with:
+  - `imageDir: string` - Directory where images should be saved
+  - `imagePathPrefix: string` - Path prefix for image references in markdown
+  - `markerDir?: string` - Optional custom directory for download markers
+- Export from `src/index.ts`
+
+**Key Requirements**:
+- Type-safe implementation (no `any` types)
+- Full JSDoc documentation matching existing patterns in `src/types/image-processor.ts`
+- Compatible with future `processWithContext()` method (Phase 3)
+
+---
+
+## Architecture Design
+
+### 1. Interface Design
+
+#### ImageProcessorContext Interface
+
+```typescript
+/**
+ * Context for image processing that includes output structure information.
+ * Used by ImageProcessor.processWithContext() for flat mode support.
+ */
+export interface ImageProcessorContext {
+  /**
+   * Directory where images should be saved.
+   * In nested mode: {output}/{slug}/
+   * In flat mode: {output}/../_images/
+   */
+  imageDir: string;
+
+  /**
+   * Path prefix for image references in markdown.
+   * In nested mode: '.'
+   * In flat mode: '/images' (or custom prefix)
+   */
+  imagePathPrefix: string;
+
+  /**
+   * Optional custom directory for download markers.
+   * Defaults to {imageDir}/.downloaded-markers/
+   */
+  markerDir?: string;
+}
+```
+
+### 2. Design Patterns
+
+Following existing patterns from `src/types/image-processor.ts`:
+- Interface-based configuration (like `ImageProcessorOptions`)
+- Required fields for essential data (`imageDir`, `imagePathPrefix`)
+- Optional fields for customization (`markerDir`)
+- Comprehensive JSDoc describing purpose and usage
+
+**Key Decisions**:
+1. **Place in existing file**: Add to `src/types/image-processor.ts` rather than creating a new file, since this context is ImageProcessor-specific
+2. **Required vs Optional fields**: `imageDir` and `imagePathPrefix` are required because they're always needed; `markerDir` is optional with sensible default
+
+---
+
+## Implementation Steps
+
+### Step 1: Add ImageProcessorContext Interface
+
+**File**: [src/types/image-processor.ts](../../../src/types/image-processor.ts)
+
+**Action**: Add the `ImageProcessorContext` interface at the end of the file (after `ImageProcessingError`)
+
+**Implementation**:
+
+```typescript
+// Add after ImageProcessingError interface (around line 94)
+
+/**
+ * Context for image processing that includes output structure information.
+ * Used by ImageProcessor.processWithContext() for flat mode support.
+ */
+export interface ImageProcessorContext {
+  /**
+   * Directory where images should be saved.
+   * In nested mode: {output}/{slug}/
+   * In flat mode: {output}/../_images/
+   */
+  imageDir: string;
+
+  /**
+   * Path prefix for image references in markdown.
+   * In nested mode: '.'
+   * In flat mode: '/images' (or custom prefix)
+   */
+  imagePathPrefix: string;
+
+  /**
+   * Optional custom directory for download markers.
+   * Defaults to {imageDir}/.downloaded-markers/
+   */
+  markerDir?: string;
+}
+```
+
+### Step 2: Update Exports in src/index.ts
+
+**File**: [src/index.ts](../../../src/index.ts)
+
+**Action**: Add `ImageProcessorContext` to the existing type export (lines 70-74)
+
+**Current**:
+```typescript
+export type {
+  ImageProcessorOptions,
+  ImageProcessingResult,
+  ImageProcessingError,
+} from './types/image-processor.js';
+```
+
+**Updated**:
+```typescript
+export type {
+  ImageProcessorOptions,
+  ImageProcessingResult,
+  ImageProcessingError,
+  ImageProcessorContext,
+} from './types/image-processor.js';
+```
+
+---
+
+## Testing Strategy
+
+### Type Definition Verification
+
+For pure type definitions, verification is done through:
+
+1. **TypeScript Compilation**: `npm run type-check` will verify:
+   - Interface syntax is correct
+   - No circular dependencies
+   - Types are properly exported
+
+2. **Build Verification**: `npm run build` will verify:
+   - Types are emitted to `dist/`
+   - Declaration files (.d.ts) are generated correctly
+
+### No Unit Tests Required
+
+Type definitions don't require unit tests because:
+- TypeScript compiler validates syntax and type correctness
+- Interfaces have no runtime behavior to test
+- Usage will be tested in Phase 3 (ImageProcessor.processWithContext)
+
+---
+
+## Integration Points
+
+### 1. Upstream (Input)
+- **Source**: `Converter` (Phase 4) will construct this context based on `OutputStructure`
+- **Input Construction**:
+  - Nested mode: `{ imageDir: '{output}/{slug}', imagePathPrefix: '.' }`
+  - Flat mode: `{ imageDir: '{output}/../_images', imagePathPrefix: '/images' }`
+
+### 2. Downstream (Output)
+- **Consumer**: `ImageProcessor.processWithContext()` (Phase 3)
+- **Usage**: Context provides explicit configuration for image directory and URL prefix
+
+### 3. Error Flow
+- Not applicable for type definitions (no runtime behavior)
+
+---
+
+## Success Criteria
+
+### Functional Requirements
+- [x] `ImageProcessorContext` interface exists with `imageDir`, `imagePathPrefix`, `markerDir`
+- [x] Interface is exported from `src/index.ts`
+
+### Non-Functional Requirements
+- [x] No `any` types
+- [x] JSDoc documentation on all fields
+- [x] TypeScript compilation passes
+- [x] Build succeeds
+
+---
+
+## Verification Checklist
+
+### Post-Implementation
+
+```bash
+# Verify TypeScript compilation
+npm run type-check
+# Expected: No TypeScript errors
+
+# Verify build succeeds
+npm run build
+# Expected: dist/ directory created with type declarations
+
+# Verify export (optional manual check)
+# Check dist/types/image-processor.d.ts contains ImageProcessorContext
+```
+
+---
+
+## Implementation Checklist
+
+- [x] Add `ImageProcessorContext` interface to `src/types/image-processor.ts`
+- [x] Add `ImageProcessorContext` to exports in `src/index.ts`
+- [x] Run `npm run type-check` - verify no errors
+- [x] Run `npm run build` - verify success
+- [x] Run `npm test` - verify all existing tests pass (358 tests passing)
+
+---
+
+## Files to Modify
+
+| File | Action |
+|------|--------|
+| [src/types/image-processor.ts](../../../src/types/image-processor.ts) | Add `ImageProcessorContext` interface |
+| [src/index.ts](../../../src/index.ts) | Add `ImageProcessorContext` to type exports |
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Type conflicts with existing code | Low | Low | Types are additive, no existing code uses `ImageProcessorContext` |
+| Circular dependency issues | Low | Low | Interface has no imports, only primitive types |
+
+---
+
+## Summary
+
+**Phase 1.2** will deliver the `ImageProcessorContext` interface that:
+- Provides explicit context for image processing (directory and path prefix)
+- Enables the ImageProcessor to support flat output mode in Phase 3
+- Follows existing patterns in `src/types/image-processor.ts`
+
+This is a low-risk, type-only change that enables subsequent implementation phases.
+
+---
+
+## Next Steps After Implementation
+
+1. Proceed to Phase 2: FileWriter Service Updates
+2. Update GitHub issue #44 to mark tasks complete

--- a/docs/features/flat/PHASE_2_STEP_2_1.md
+++ b/docs/features/flat/PHASE_2_STEP_2_1.md
@@ -1,0 +1,377 @@
+# Phase 2.1: Add outputMode Configuration to FileWriter - Implementation Plan
+
+**Issue**: [#45 - Add outputMode Configuration to FileWriter](https://github.com/alvincrespo/hashnode-content-converter/issues/45)
+**Status**: PLANNED
+**Date**: 2026-01-12
+**Phase**: Phase 2 (FileWriter Service Updates), Step 2.1
+
+---
+
+## Overview
+
+Add `outputMode` configuration to the `FileWriter` service to support flat vs nested output modes. This is a foundational change that adds the configuration infrastructure - the actual behavior changes (updating `postExists` and `writePost` methods) will be implemented in subsequent steps (2.2 and 2.3).
+
+**Scope**: Configuration only - add property to interface, class, and constructor. No behavior changes in this step.
+
+**Reference**: [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) (lines 311-346)
+
+---
+
+## Requirements Summary
+
+From [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) (lines 313-346):
+
+- Add `outputMode` to `FileWriterConfig` interface
+- Store output mode in class property
+- Update constructor to accept new config
+- Default value should be `'nested'` for backwards compatibility
+
+**Key Requirements**:
+- 90%+ test coverage for new code
+- Type-safe implementation (no `any` types)
+- Full JSDoc documentation
+- Backwards compatible - existing code should work without changes
+
+---
+
+## Architecture Design
+
+### 1. Configuration Interface Update
+
+**File**: `src/services/file-writer.ts`
+
+```typescript
+export interface FileWriterConfig {
+  overwrite?: boolean;
+  encoding?: BufferEncoding;
+  atomicWrites?: boolean;
+
+  /**
+   * Output mode for file organization:
+   * - 'nested': Creates {slug}/index.md (default)
+   * - 'flat': Creates {slug}.md directly in output directory
+   * @default 'nested'
+   */
+  outputMode?: 'nested' | 'flat';
+}
+```
+
+### 2. Class Property Refactor
+
+Replace individual properties with a single config object:
+
+```typescript
+export class FileWriter {
+  /**
+   * Default configuration values
+   */
+  private static readonly DEFAULTS: Required<FileWriterConfig> = {
+    overwrite: false,
+    encoding: 'utf8',
+    atomicWrites: true,
+    outputMode: 'nested',
+  };
+
+  /**
+   * Resolved configuration with defaults applied
+   */
+  private readonly config: Required<FileWriterConfig>;
+
+  constructor(config?: FileWriterConfig) {
+    this.config = { ...FileWriter.DEFAULTS, ...config };
+  }
+  // ...
+}
+```
+
+### 3. Update Property References
+
+All property access changes from `this.propertyName` to `this.config.propertyName`:
+
+| Before | After |
+|--------|-------|
+| `this.overwrite` | `this.config.overwrite` |
+| `this.encoding` | `this.config.encoding` |
+| `this.atomicWrites` | `this.config.atomicWrites` |
+| `this.outputMode` | `this.config.outputMode` |
+
+This approach:
+- Reduces class properties from 4 to 1
+- Centralizes defaults in one place
+- Makes the constructor a single line
+- Groups related config together
+
+---
+
+## Implementation Steps
+
+### Step 1: Update FileWriterConfig Interface
+
+**File**: `src/services/file-writer.ts` (lines 7-26)
+
+**Action**: Add `outputMode` property with JSDoc documentation
+
+**Implementation**:
+```typescript
+export interface FileWriterConfig {
+  /**
+   * Whether to overwrite existing files
+   * @default false - throw error if file exists
+   */
+  overwrite?: boolean;
+
+  /**
+   * File encoding for markdown files
+   * @default 'utf8'
+   */
+  encoding?: BufferEncoding;
+
+  /**
+   * Enable atomic writes (write to temp file, then rename)
+   * Prevents partial writes on failure
+   * @default true
+   */
+  atomicWrites?: boolean;
+
+  /**
+   * Output mode for file organization:
+   * - 'nested': Creates {slug}/index.md (default)
+   * - 'flat': Creates {slug}.md directly in output directory
+   * @default 'nested'
+   */
+  outputMode?: 'nested' | 'flat';
+}
+```
+
+### Step 2: Refactor Class Properties and Constructor
+
+**File**: `src/services/file-writer.ts` (lines 54-63)
+
+**Action**: Replace individual properties with static DEFAULTS and single config object
+
+**Before** (current):
+```typescript
+export class FileWriter {
+  private readonly overwrite: boolean;
+  private readonly encoding: BufferEncoding;
+  private readonly atomicWrites: boolean;
+
+  constructor(config?: FileWriterConfig) {
+    this.overwrite = config?.overwrite ?? false;
+    this.encoding = config?.encoding ?? 'utf8';
+    this.atomicWrites = config?.atomicWrites ?? true;
+  }
+```
+
+**After** (new):
+```typescript
+export class FileWriter {
+  /**
+   * Default configuration values
+   */
+  private static readonly DEFAULTS: Required<FileWriterConfig> = {
+    overwrite: false,
+    encoding: 'utf8',
+    atomicWrites: true,
+    outputMode: 'nested',
+  };
+
+  /**
+   * Resolved configuration with defaults applied
+   */
+  private readonly config: Required<FileWriterConfig>;
+
+  constructor(config?: FileWriterConfig) {
+    this.config = { ...FileWriter.DEFAULTS, ...config };
+  }
+```
+
+### Step 3: Update Property References
+
+**File**: `src/services/file-writer.ts` (throughout class)
+
+**Action**: Find and replace all property accesses
+
+| Location | Before | After |
+|----------|--------|-------|
+| Line 116, 121 | `this.encoding` | `this.config.encoding` |
+| Line 166 | `this.encoding` | `this.config.encoding` |
+| Line 212 | `this.overwrite` | `this.config.overwrite` |
+| Line 236 | `this.atomicWrites` | `this.config.atomicWrites` |
+
+**Note**: Use find/replace with word boundaries to avoid false matches.
+
+---
+
+## Testing Strategy
+
+### 1. Unit Test Approach
+
+**File**: `tests/unit/file-writer.test.ts`
+
+**Test Categories**:
+
+#### A. Constructor Configuration Tests (4 tests)
+- `should default outputMode to 'nested' when not provided`
+- `should accept 'nested' outputMode`
+- `should accept 'flat' outputMode`
+- `should use default values when config is undefined`
+
+**Total Tests**: ~4 new tests (targeting 100% coverage of new code)
+
+### 2. Proposed Test Implementation
+
+```typescript
+describe('outputMode Configuration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.promises.mkdir).mockResolvedValue(undefined);
+    vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined);
+    vi.mocked(fs.promises.rename).mockResolvedValue(undefined);
+  });
+
+  it('should default outputMode to nested when not provided', async () => {
+    const writer = new FileWriter();
+    // Verify nested behavior (creates {slug}/index.md)
+    const result = await writer.writePost('./blog', 'my-post', '---\n', 'content');
+    expect(result).toContain('my-post/index.md');
+  });
+
+  it('should accept nested outputMode explicitly', async () => {
+    const writer = new FileWriter({ outputMode: 'nested' });
+    const result = await writer.writePost('./blog', 'my-post', '---\n', 'content');
+    expect(result).toContain('my-post/index.md');
+  });
+
+  it('should accept flat outputMode', () => {
+    // For now, just verify the config is accepted without error
+    // Actual flat behavior will be tested in Step 2.3
+    const writer = new FileWriter({ outputMode: 'flat' });
+    expect(writer).toBeInstanceOf(FileWriter);
+  });
+
+  it('should use default values when config is undefined', async () => {
+    const writer = new FileWriter(undefined);
+    const result = await writer.writePost('./blog', 'my-post', '---\n', 'content');
+    expect(result).toContain('my-post/index.md');
+  });
+});
+```
+
+### 3. Test Coverage Targets
+
+| Metric | Target | Rationale |
+|--------|--------|-----------|
+| **Statements** | 100% | All new lines exercised |
+| **Branches** | 100% | Default value branch tested |
+| **Functions** | 100% | Constructor already tested |
+| **Lines** | 100% | Complete line coverage |
+
+---
+
+## Integration Points
+
+### 1. Upstream (Input)
+- **Source**: CLI (`src/cli/convert.ts`) and Converter (`src/converter.ts`)
+- **Input Type**: `FileWriterConfig`
+- **Integration**: Config passed to FileWriter constructor
+
+### 2. Downstream (Output)
+- **Output Type**: Stored internally, used by `postExists()` and `writePost()`
+- **Next Steps**: Steps 2.2 and 2.3 will use this property to change behavior
+
+### 3. Dependencies
+- **Phase 1 (Types)**: `OutputStructure` interface already exists in `src/types/converter-options.ts`
+- **Note**: `FileWriterConfig.outputMode` is separate from `OutputStructure.mode` - both use the same `'nested' | 'flat'` union type
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/services/file-writer.ts` | Add outputMode to interface, refactor to single config object |
+| `tests/unit/file-writer.test.ts` | Add configuration tests |
+
+---
+
+## Verification Checklist
+
+### Pre-Implementation
+- [x] GitHub Issue reviewed
+- [x] Type definitions understood (OutputStructure already exists)
+- [x] Current FileWriter implementation analyzed
+- [x] Test patterns studied
+
+### Post-Implementation
+
+```bash
+# Verify TypeScript compilation
+npm run type-check
+# Expected: No TypeScript errors
+
+# Verify build succeeds
+npm run build
+# Expected: dist/ directory created
+
+# Run tests
+npm test
+# Expected: All tests pass (existing + new)
+
+# Generate coverage report
+npm run test:coverage
+# Expected: 90%+ coverage maintained
+```
+
+---
+
+## Implementation Checklist
+
+### Phase 1: Core Implementation
+- [x] Add `outputMode` property to `FileWriterConfig` interface with JSDoc
+- [x] Add static `DEFAULTS` object with all default values (including `outputMode: 'nested'`)
+- [x] Replace individual class properties with single `config: Required<FileWriterConfig>`
+- [x] Refactor constructor to single line: `this.config = { ...DEFAULTS, ...config }`
+- [x] Update all property references from `this.x` to `this.config.x`
+
+### Phase 2: Testing
+- [x] Add `describe('outputMode Configuration')` test block
+- [x] Write 4 unit tests for configuration handling
+- [x] Verify all existing tests still pass
+
+### Phase 3: Verification
+- [x] Run `npm run type-check` - no errors
+- [x] Run `npm run build` - succeeds
+- [x] Run `npm test` - all tests pass (362 total)
+- [x] Run `npm run test:coverage` - 99.35% coverage maintained
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Breaking existing behavior | Low | High | Default to 'nested', all existing tests should pass |
+| Type conflicts with OutputStructure | Low | Low | Both use same union type, no conflict |
+
+---
+
+## Summary
+
+**Phase 2.1** will add the `outputMode` configuration infrastructure to FileWriter:
+
+- Add `outputMode?: 'nested' | 'flat'` to `FileWriterConfig` interface
+- Refactor to single `config` object with static `DEFAULTS`
+- Default to `'nested'` for backwards compatibility
+- Add 4 unit tests for configuration handling
+
+**Ready to implement?** This is a minimal, focused change that sets up the foundation for behavior changes in Steps 2.2 and 2.3.
+
+---
+
+## Next Steps After Implementation
+
+1. **Step 2.2**: Update `postExists()` method to check for `{slug}.md` in flat mode
+2. **Step 2.3**: Update `writePost()` method to write `{slug}.md` in flat mode
+3. **Step 2.4**: Write comprehensive FileWriter unit tests for flat mode behavior

--- a/docs/features/flat/PHASE_2_STEP_2_2.md
+++ b/docs/features/flat/PHASE_2_STEP_2_2.md
@@ -1,0 +1,378 @@
+# Phase 2.2: Update FileWriter postExists Method - Implementation Plan
+
+**Issue**: [#46 - 2.2 Update FileWriter postExists Method](https://github.com/alvincrespo/hashnode-content-converter/issues/46)
+**Status**: IMPLEMENTED
+**Date**: 2026-01-13
+**Phase**: Phase 2 - FileWriter Service Updates
+
+---
+
+## Overview
+
+Update the `postExists` method in FileWriter to check for `{slug}.md` files in flat mode instead of `{slug}/` directories in nested mode. This enables the `skipExisting` feature to work correctly with flat output mode.
+
+**Scope**:
+- IN SCOPE: Update `postExists()` method, add unit tests for flat mode
+- OUT OF SCOPE: `writePost()` changes (Step 2.3), Converter integration (Step 4.2)
+
+**Reference**: [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) (lines 348-378)
+
+---
+
+## Requirements Summary
+
+From GitHub Issue #46:
+
+- Check for `{slug}.md` file in flat mode
+- Check for `{slug}/` directory in nested mode (current behavior)
+- Add unit tests for flat mode existence check
+
+**Key Requirements**:
+- 90%+ test coverage for new code
+- Type-safe implementation (no `any` types)
+- Backwards compatible - nested mode unchanged
+- Graceful error handling (return false on errors)
+
+---
+
+## Architecture Design
+
+### 1. Method API (No Change)
+
+```typescript
+/**
+ * Check if a post already exists in the output directory.
+ * In nested mode, checks for directory existence.
+ * In flat mode, checks for {slug}.md file existence.
+ */
+postExists(outputDir: string, slug: string): boolean
+```
+
+### 2. Behavior by Mode
+
+| Mode | Check | Path Pattern | Example |
+|------|-------|--------------|---------|
+| Nested (default) | Directory exists | `{outputDir}/{slug}/` | `./blog/my-post/` |
+| Flat | File exists | `{outputDir}/{slug}.md` | `./blog/my-post.md` |
+
+### 3. Design Decisions
+
+1. **Use existing `outputMode` config**: Already added in Step 2.1, stored in `this.config.outputMode`
+2. **Maintain graceful error handling**: Keep try-catch, return false on errors
+3. **Reuse `sanitizeSlug()`**: Both modes use the same slug sanitization
+
+---
+
+## Technical Approach
+
+### Data Flow
+
+```
+postExists(outputDir, slug)
+    │
+    ▼
+sanitizeSlug(slug)  ─── throws? ──► return false
+    │
+    ▼
+if (this.config.outputMode === 'flat')
+    │                    │
+    ▼                    ▼
+  FLAT MODE           NESTED MODE
+    │                    │
+    ▼                    ▼
+path.join(outputDir,  path.join(outputDir,
+  `${sanitized}.md`)    sanitized)
+    │                    │
+    ▼                    ▼
+fs.existsSync(path)   fs.existsSync(path)
+    │                    │
+    └────────┬───────────┘
+             ▼
+       return result
+```
+
+---
+
+## Implementation Steps
+
+### Step 1: Update postExists Method
+
+**File**: [src/services/file-writer.ts](../../../src/services/file-writer.ts)
+
+**Lines**: 200-209
+
+**Current Implementation**:
+```typescript
+postExists(outputDir: string, slug: string): boolean {
+  try {
+    const sanitized = this.sanitizeSlug(slug);
+    const postDir = path.join(outputDir, sanitized);
+    return fs.existsSync(postDir);
+  } catch {
+    return false;
+  }
+}
+```
+
+**New Implementation**:
+```typescript
+/**
+ * Check if a post already exists in the output directory.
+ * In nested mode, checks for directory existence.
+ * In flat mode, checks for {slug}.md file existence.
+ * @param outputDir - Base output directory
+ * @param slug - Post slug to check
+ * @returns True if post exists, false otherwise (including on errors)
+ */
+postExists(outputDir: string, slug: string): boolean {
+  try {
+    let sanitized = this.sanitizeSlug(slug);
+
+    // Flat mode: check for {slug}.md file
+    if (this.config.outputMode === 'flat') {
+      sanitized = `${sanitized}.md`;
+    }
+
+    const postPath = path.join(outputDir, sanitized);
+    return fs.existsSync(postPath);
+  } catch {
+    // If sanitization fails, the post doesn't exist (invalid slug)
+    return false;
+  }
+}
+```
+
+---
+
+## Testing Strategy
+
+### 1. Unit Test Approach
+
+**File**: [tests/unit/file-writer.test.ts](../../../tests/unit/file-writer.test.ts)
+
+**Test Categories**:
+
+#### A. Flat Mode - postExists() (4 tests)
+- Test: return true when `{slug}.md` file exists
+- Test: return false when `{slug}.md` file does not exist
+- Test: check for file, not directory (directory exists but file doesn't = false)
+- Test: return false on invalid slug (graceful error handling)
+
+#### B. Nested Mode Regression (2 tests)
+- Test: nested mode unchanged - checks for directory
+- Test: nested mode with explicit config still works
+
+**Total New Tests**: ~6 tests (targeting 100% coverage of new code paths)
+
+### 2. Test Implementation
+
+```typescript
+describe('postExists() - Flat Mode', () => {
+  it('should return true when {slug}.md file exists in flat mode', () => {
+    const flatWriter = new FileWriter({ outputMode: 'flat' });
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+
+    const result = flatWriter.postExists('./blog', 'test-post');
+
+    expect(result).toBe(true);
+    expect(fs.existsSync).toHaveBeenCalledWith(
+      expect.stringMatching(/test-post\.md$/)
+    );
+  });
+
+  it('should return false when {slug}.md does not exist in flat mode', () => {
+    const flatWriter = new FileWriter({ outputMode: 'flat' });
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    const result = flatWriter.postExists('./blog', 'non-existent');
+
+    expect(result).toBe(false);
+  });
+
+  it('should check for file, not directory, in flat mode', () => {
+    const flatWriter = new FileWriter({ outputMode: 'flat' });
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    flatWriter.postExists('./blog', 'my-post');
+
+    // Verify it checks for .md file, not directory
+    expect(fs.existsSync).toHaveBeenCalledWith(
+      expect.stringContaining('my-post.md')
+    );
+  });
+
+  it('should return false on invalid slug in flat mode', () => {
+    const flatWriter = new FileWriter({ outputMode: 'flat' });
+
+    // Invalid slug triggers sanitization error
+    const result = flatWriter.postExists('./blog', '/invalid/slug');
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('postExists() - Nested Mode Regression', () => {
+  it('should check for directory in nested mode (default)', () => {
+    const nestedWriter = new FileWriter(); // Default is nested
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+
+    nestedWriter.postExists('./blog', 'my-post');
+
+    // Should NOT have .md extension
+    expect(fs.existsSync).toHaveBeenCalledWith(
+      expect.not.stringContaining('.md')
+    );
+  });
+
+  it('should check for directory with explicit nested config', () => {
+    const nestedWriter = new FileWriter({ outputMode: 'nested' });
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+
+    const result = nestedWriter.postExists('./blog', 'my-post');
+
+    expect(result).toBe(true);
+  });
+});
+```
+
+### 3. Test Coverage Targets
+
+| Metric | Target | Rationale |
+|--------|--------|-----------|
+| Statements | 100% | All new code paths exercised |
+| Branches | 100% | Both flat and nested branches tested |
+| Functions | 100% | postExists() fully covered |
+| Lines | 100% | All new lines covered |
+
+---
+
+## Integration Points
+
+### 1. Upstream (Input)
+- **Source**: Converter.convertAllPosts() at line 274
+- **Integration**: Uses `this.fileWriter.postExists(outputDir, slug)` for skipExisting check
+
+### 2. Downstream (Output)
+- **Output**: Boolean indicating post existence
+- **Consumer**: Converter skip logic
+
+### 3. Dependencies
+- **Step 2.1**: `outputMode` config (COMPLETED)
+- **Step 2.3**: `writePost()` must use same mode logic (NEXT)
+
+---
+
+## Potential Challenges & Solutions
+
+### Challenge 1: Mixed Mode Output Directories
+
+**Issue**: User runs nested mode first, then flat mode on same directory. `postExists()` would return false in flat mode even though nested post exists.
+
+**Solution**: This is expected behavior - modes are independent. Document that switching modes doesn't detect posts from other mode.
+
+**Risk Level**: Low (expected behavior)
+
+### Challenge 2: Ensuring Path Pattern Consistency
+
+**Issue**: `postExists()` path pattern must match `writePost()` pattern for consistency.
+
+**Solution**: Step 2.3 will implement matching logic. Both use `path.join(outputDir, `${sanitized}.md`)` for flat mode.
+
+**Risk Level**: Low (handled by implementation)
+
+---
+
+## Success Criteria
+
+### Functional Requirements
+- [ ] postExists() returns true for existing `{slug}.md` files in flat mode
+- [ ] postExists() returns false for non-existent files in flat mode
+- [ ] postExists() nested mode behavior unchanged (regression tests pass)
+- [ ] Graceful error handling maintained (return false on errors)
+
+### Non-Functional Requirements
+- [ ] 100% test coverage on new code paths
+- [ ] No `any` types
+- [ ] JSDoc updated with flat mode documentation
+- [ ] TypeScript compilation passes
+- [ ] All existing tests pass
+
+---
+
+## Verification Checklist
+
+### Pre-Implementation
+- [x] GitHub Issue reviewed (#46)
+- [x] Source document analyzed (IMPLEMENTATION_FLAT.md lines 348-378)
+- [x] Current implementation understood (file-writer.ts lines 200-209)
+- [x] Test patterns studied (file-writer.test.ts)
+- [x] Step 2.1 verified complete (outputMode config exists)
+
+### Post-Implementation
+```bash
+# Verify TypeScript compilation
+npm run type-check
+# Expected: No TypeScript errors
+
+# Verify build succeeds
+npm run build
+# Expected: dist/ directory created
+
+# Run tests
+npm test
+# Expected: All tests pass
+
+# Generate coverage report
+npm run test:coverage
+# Expected: 99%+ coverage maintained
+```
+
+---
+
+## Implementation Checklist
+
+### Phase 1: Core Implementation
+- [ ] Update JSDoc for postExists() method
+- [ ] Add flat mode conditional check
+- [ ] Build file path with `.md` extension for flat mode
+- [ ] Keep nested mode logic unchanged
+
+### Phase 2: Testing
+- [ ] Add "postExists() - Flat Mode" describe block
+- [ ] Write 4 flat mode tests
+- [ ] Add 2 nested mode regression tests
+- [ ] Verify coverage targets met
+
+### Phase 3: Verification
+- [ ] Run type-check
+- [ ] Run build
+- [ ] Run all tests
+- [ ] Review coverage report
+
+---
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| [src/services/file-writer.ts](../../../src/services/file-writer.ts) | Update postExists() method (lines 200-209) |
+| [tests/unit/file-writer.test.ts](../../../tests/unit/file-writer.test.ts) | Add ~6 new tests |
+
+---
+
+## Summary
+
+**Step 2.2** will update the `postExists()` method to support flat output mode by:
+- Checking for `{slug}.md` files when `outputMode: 'flat'`
+- Maintaining backwards compatibility with nested mode
+- Adding comprehensive unit tests for both modes
+
+This change enables the `skipExisting` feature to work correctly with flat output mode, which is essential for the overall flat mode implementation.
+
+---
+
+## Next Steps After Implementation
+
+1. Mark Step 2.2 as complete in [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md)
+2. Proceed to Step 2.3: Update writePost Method
+3. Close GitHub Issue #46

--- a/docs/features/flat/PHASE_2_STEP_2_2.md
+++ b/docs/features/flat/PHASE_2_STEP_2_2.md
@@ -285,17 +285,17 @@ describe('postExists() - Nested Mode Regression', () => {
 ## Success Criteria
 
 ### Functional Requirements
-- [ ] postExists() returns true for existing `{slug}.md` files in flat mode
-- [ ] postExists() returns false for non-existent files in flat mode
-- [ ] postExists() nested mode behavior unchanged (regression tests pass)
-- [ ] Graceful error handling maintained (return false on errors)
+- [x] postExists() returns true for existing `{slug}.md` files in flat mode
+- [x] postExists() returns false for non-existent files in flat mode
+- [x] postExists() nested mode behavior unchanged (regression tests pass)
+- [x] Graceful error handling maintained (return false on errors)
 
 ### Non-Functional Requirements
-- [ ] 100% test coverage on new code paths
-- [ ] No `any` types
-- [ ] JSDoc updated with flat mode documentation
-- [ ] TypeScript compilation passes
-- [ ] All existing tests pass
+- [x] 100% test coverage on new code paths
+- [x] No `any` types
+- [x] JSDoc updated with flat mode documentation
+- [x] TypeScript compilation passes
+- [x] All existing tests pass
 
 ---
 
@@ -332,22 +332,22 @@ npm run test:coverage
 ## Implementation Checklist
 
 ### Phase 1: Core Implementation
-- [ ] Update JSDoc for postExists() method
-- [ ] Add flat mode conditional check
-- [ ] Build file path with `.md` extension for flat mode
-- [ ] Keep nested mode logic unchanged
+- [x] Update JSDoc for postExists() method
+- [x] Add flat mode conditional check
+- [x] Build file path with `.md` extension for flat mode
+- [x] Keep nested mode logic unchanged
 
 ### Phase 2: Testing
-- [ ] Add "postExists() - Flat Mode" describe block
-- [ ] Write 4 flat mode tests
-- [ ] Add 2 nested mode regression tests
-- [ ] Verify coverage targets met
+- [x] Add "postExists() - Flat Mode" describe block
+- [x] Write 4 flat mode tests
+- [x] Add 2 nested mode regression tests
+- [x] Verify coverage targets met
 
 ### Phase 3: Verification
-- [ ] Run type-check
-- [ ] Run build
-- [ ] Run all tests
-- [ ] Review coverage report
+- [x] Run type-check
+- [x] Run build
+- [x] Run all tests
+- [x] Review coverage report
 
 ---
 

--- a/docs/features/flat/PHASE_2_STEP_2_3.md
+++ b/docs/features/flat/PHASE_2_STEP_2_3.md
@@ -1,0 +1,401 @@
+# Phase 2.3: Update FileWriter writePost Method - Implementation Plan
+
+**Issue**: [#47 - 2.3 Update FileWriter writePost Method](https://github.com/alvincrespo/hashnode-content-converter/issues/47)
+**Status**: IMPLEMENTED
+**Date**: 2026-01-13
+**Phase**: Phase 2 - FileWriter Service Updates (Step 2.3 of 2.4)
+
+---
+
+## Overview
+
+Update the `writePost` method in the FileWriter service to support flat output mode. Currently, `writePost` always creates a subdirectory structure (`{slug}/index.md`). This change will add conditional logic to write `{slug}.md` directly in the output directory when `outputMode: 'flat'` is configured.
+
+**Scope**:
+- **In scope**: Modify `writePost` method, add unit tests for flat mode behavior
+- **Out of scope**: CLI integration (Phase 5), Converter integration (Phase 4)
+
+**Reference**: [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) (lines 380-458)
+
+---
+
+## Requirements Summary
+
+From [IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) (lines 380-458):
+
+- Write to `{slug}.md` in flat mode (no subdirectory)
+- Write to `{slug}/index.md` in nested mode (current behavior, unchanged)
+- Ensure output directory exists in flat mode (but don't create post subdirectory)
+- Add unit tests for flat mode file writing
+- Maintain backwards compatibility - default behavior unchanged
+
+**Key Requirements**:
+- 90%+ test coverage for new code
+- Type-safe implementation (no `any` types)
+- Maintain existing error handling patterns
+- Preserve atomic writes behavior in both modes
+
+---
+
+## Architecture Design
+
+### 1. Current Implementation (lines 228-269)
+
+```typescript
+async writePost(outputDir: string, slug: string, frontmatter: string, content: string): Promise<string> {
+  const sanitized = this.sanitizeSlug(slug);
+
+  // CURRENT: Always creates subdirectory
+  const postDir = path.join(outputDir, sanitized);
+  const filePath = path.join(postDir, 'index.md');
+
+  // Check overwrite behavior
+  if (!this.config.overwrite && fs.existsSync(filePath)) { ... }
+
+  // CURRENT: Always creates post subdirectory
+  await fs.promises.mkdir(postDir, { recursive: true });
+
+  // Write file
+  const markdown = frontmatter + '\n' + content;
+  if (this.config.atomicWrites) {
+    await this.writeFileAtomic(filePath, markdown);
+  } else {
+    await this.writeFileDirect(filePath, markdown);
+  }
+
+  return path.resolve(filePath);
+}
+```
+
+### 2. Updated Design
+
+```typescript
+async writePost(outputDir: string, slug: string, frontmatter: string, content: string): Promise<string> {
+  const sanitized = this.sanitizeSlug(slug);
+  let filePath: string;
+
+  if (this.config.outputMode === 'flat') {
+    // Flat mode: {output}/{slug}.md
+    filePath = path.join(outputDir, `${sanitized}.md`);
+
+    // Ensure output directory exists (not post subdirectory)
+    if (!fs.existsSync(outputDir)) {
+      await fs.promises.mkdir(outputDir, { recursive: true });
+    }
+  } else {
+    // Nested mode: {output}/{slug}/index.md
+    const postDir = path.join(outputDir, sanitized);
+    filePath = path.join(postDir, 'index.md');
+
+    // Create post subdirectory
+    await fs.promises.mkdir(postDir, { recursive: true });
+  }
+
+  // Check overwrite (same path variable for both modes)
+  if (!this.config.overwrite && fs.existsSync(filePath)) { ... }
+
+  // Write file (unchanged)
+  const markdown = frontmatter + '\n' + content;
+  if (this.config.atomicWrites) {
+    await this.writeFileAtomic(filePath, markdown);
+  } else {
+    await this.writeFileDirect(filePath, markdown);
+  }
+
+  return path.resolve(filePath);
+}
+```
+
+### 3. Key Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Mode check before directory creation | Flat mode only needs output directory, not subdirectory |
+| Reuse existing atomic write helpers | No changes needed to `writeFileAtomic` or `writeFileDirect` |
+| Single `filePath` variable | Simplifies overwrite check and write operations |
+| Check `outputDir` existence only in flat mode | Nested mode's `mkdir` with `recursive: true` handles this |
+
+---
+
+## Implementation Steps
+
+### Step 1: Update writePost Method
+
+**File**: [src/services/file-writer.ts](../../../src/services/file-writer.ts)
+
+**Location**: Lines 228-269 (replace entire method)
+
+**Implementation**:
+
+```typescript
+/**
+ * Write a blog post with frontmatter and content to the filesystem
+ * @param outputDir - Base output directory (e.g., './blog')
+ * @param slug - Post slug (used as filename in flat mode, subdirectory in nested mode)
+ * @param frontmatter - YAML frontmatter string (includes --- markers)
+ * @param content - Markdown content body
+ * @returns Absolute path to the written file
+ * @throws FileWriteError if write fails or file exists (when overwrite=false)
+ */
+async writePost(outputDir: string, slug: string, frontmatter: string, content: string): Promise<string> {
+  // Sanitize slug for filesystem safety
+  const sanitized = this.sanitizeSlug(slug);
+  let filePath: string;
+
+  if (this.config.outputMode === 'flat') {
+    // Flat mode: write {output}/{slug}.md directly
+    filePath = path.join(outputDir, `${sanitized}.md`);
+
+    // Ensure output directory exists (but don't create post subdirectory)
+    if (!fs.existsSync(outputDir)) {
+      try {
+        await fs.promises.mkdir(outputDir, { recursive: true });
+      } catch (error) {
+        throw new FileWriteError(
+          `Failed to create directory: ${error instanceof Error ? error.message : String(error)}`,
+          outputDir,
+          'create_dir',
+          error instanceof Error ? error : undefined
+        );
+      }
+    }
+  } else {
+    // Nested mode: write {output}/{slug}/index.md
+    const postDir = path.join(outputDir, sanitized);
+    filePath = path.join(postDir, 'index.md');
+
+    // Create post directory (recursive)
+    try {
+      await fs.promises.mkdir(postDir, { recursive: true });
+    } catch (error) {
+      throw new FileWriteError(
+        `Failed to create directory: ${error instanceof Error ? error.message : String(error)}`,
+        postDir,
+        'create_dir',
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  // Check if file exists and handle overwrite behavior
+  if (!this.config.overwrite && fs.existsSync(filePath)) {
+    throw new FileWriteError(
+      `File already exists and overwrite is disabled: ${filePath}`,
+      filePath,
+      'write_file'
+    );
+  }
+
+  // Combine frontmatter + content
+  const markdown = frontmatter + '\n' + content;
+
+  // Write to file using selected strategy
+  if (this.config.atomicWrites) {
+    await this.writeFileAtomic(filePath, markdown);
+  } else {
+    await this.writeFileDirect(filePath, markdown);
+  }
+
+  // Return absolute path to written file
+  return path.resolve(filePath);
+}
+```
+
+---
+
+## Testing Strategy
+
+### 1. Test File Location
+
+**File**: [tests/unit/file-writer.test.ts](../../../tests/unit/file-writer.test.ts)
+
+### 2. New Test Cases
+
+Add a new describe block after `describe('outputMode Configuration', ...)` (around line 515):
+
+```typescript
+describe('writePost - flat mode', () => {
+  let flatWriter: FileWriter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    flatWriter = new FileWriter({ outputMode: 'flat' });
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.promises.mkdir).mockResolvedValue(undefined);
+    vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined);
+    vi.mocked(fs.promises.rename).mockResolvedValue(undefined);
+  });
+
+  // ... test cases below
+});
+```
+
+### 3. Test Cases (~10 tests)
+
+#### A. File Path Tests (3 tests)
+- `should write {slug}.md directly in output directory` - Verify output path ends with `my-post.md` not `my-post/index.md`
+- `should NOT create subdirectory in flat mode` - Verify mkdir called with outputDir, not postDir
+- `should return absolute path ending with {slug}.md` - Verify returned path format
+
+#### B. Directory Creation Tests (3 tests)
+- `should create output directory if it does not exist` - Verify mkdir called when outputDir missing
+- `should not call mkdir when output directory already exists` - Verify mkdir skipped if existsSync returns true for outputDir
+- `should throw FileWriteError on mkdir failure` - Verify error handling
+
+#### C. Overwrite Behavior Tests (2 tests)
+- `should throw error if {slug}.md exists and overwrite is false` - Verify overwrite check uses correct path
+- `should overwrite {slug}.md when overwrite is true` - Verify overwrite works in flat mode
+
+#### D. Atomic Writes Tests (2 tests)
+- `should use atomic writes for flat mode files` - Verify .tmp file pattern
+- `should use direct writes when atomicWrites is false in flat mode`
+
+**Total Tests**: ~10 new tests (targeting 100% coverage of flat mode code path)
+
+### 4. Test Coverage Targets
+
+| Metric | Target | Rationale |
+|--------|--------|-----------|
+| **Statements** | >= 90% | All flat mode code paths exercised |
+| **Branches** | >= 90% | Both `outputMode` conditions tested |
+| **Functions** | 100% | writePost method fully covered |
+| **Lines** | >= 90% | Complete line coverage |
+
+---
+
+## Integration Points
+
+### 1. Upstream Dependencies (Complete)
+- **Step 2.1**: `outputMode` config already in `FileWriterConfig` interface
+- **Step 2.2**: `postExists` already handles flat mode
+
+### 2. Downstream Dependencies (Future)
+- **Phase 4**: Converter will create FileWriter with `{ outputMode: 'flat' }` when `outputStructure.mode === 'flat'`
+- **Phase 5**: CLI will pass `--flat` flag through to ConversionOptions
+
+### 3. Error Flow
+- FileWriteError propagates to Converter.convertPost which wraps in ConversionError
+- Logger tracks failures in conversion result
+
+---
+
+## Potential Challenges & Solutions
+
+### Challenge 1: Directory Existence Check Timing
+
+**Issue**: In flat mode, we check `fs.existsSync(outputDir)` before mkdir. This is a race condition if another process creates the directory between check and mkdir.
+
+**Solution**: Use `mkdir({ recursive: true })` which is idempotent - it succeeds even if directory exists. Only skip mkdir for performance optimization.
+
+**Risk Level**: Low (mkdir is safe either way)
+
+### Challenge 2: Overwrite Check Path Consistency
+
+**Issue**: Must ensure overwrite check uses the correct `filePath` variable for each mode.
+
+**Solution**: Single `filePath` variable set conditionally before overwrite check ensures consistency.
+
+**Risk Level**: Low (clear code structure)
+
+---
+
+## Success Criteria
+
+### Functional Requirements
+- [ ] `writePost` writes `{slug}.md` in flat mode
+- [ ] `writePost` writes `{slug}/index.md` in nested mode (unchanged)
+- [ ] Output directory created if missing in flat mode
+- [ ] No subdirectory created in flat mode
+- [ ] Atomic writes work correctly in flat mode
+- [ ] Overwrite behavior works correctly in flat mode
+
+### Non-Functional Requirements
+- [ ] 90%+ test coverage on new code paths
+- [ ] No `any` types in production code
+- [ ] JSDoc updated for `writePost` method
+- [ ] TypeScript compilation passes
+- [ ] Build succeeds
+- [ ] All existing tests pass (no regressions)
+
+### Code Quality
+- [ ] Follows existing patterns (error handling, async/await)
+- [ ] Clear conditional structure for mode branching
+- [ ] Maintains single responsibility
+
+---
+
+## Verification Checklist
+
+### Pre-Implementation
+- [x] GitHub Issue reviewed (#47)
+- [x] Current implementation analyzed (lines 228-269)
+- [x] Existing test patterns understood
+- [x] Dependencies verified (Step 2.1, 2.2 complete)
+
+### Post-Implementation
+
+```bash
+# Verify TypeScript compilation
+nvm use $(cat .node-version) && npm run type-check
+# Expected: No TypeScript errors
+
+# Verify build succeeds
+nvm use $(cat .node-version) && npm run build
+# Expected: dist/ directory created
+
+# Run tests
+nvm use $(cat .node-version) && npm test
+# Expected: All tests pass
+
+# Generate coverage report
+nvm use $(cat .node-version) && npm run test:coverage
+# Expected: >= 90% coverage
+```
+
+---
+
+## Implementation Checklist
+
+### Phase 1: Core Implementation
+- [ ] Update `writePost` method in `src/services/file-writer.ts`
+- [ ] Update JSDoc for method to document both modes
+
+### Phase 2: Testing
+- [ ] Add `describe('writePost - flat mode', ...)` test block
+- [ ] Write file path tests (3 tests)
+- [ ] Write directory creation tests (3 tests)
+- [ ] Write overwrite behavior tests (2 tests)
+- [ ] Write atomic writes tests (2 tests)
+- [ ] Verify all existing tests still pass
+
+### Phase 3: Verification
+- [ ] Run type-check
+- [ ] Run build
+- [ ] Run tests
+- [ ] Review coverage report
+
+### Phase 4: Documentation
+- [ ] Mark Step 2.3 as complete in IMPLEMENTATION_FLAT.md
+- [ ] Update GitHub issue #47
+
+---
+
+## Files to Modify
+
+| File | Action |
+|------|--------|
+| [src/services/file-writer.ts](../../../src/services/file-writer.ts) | Update `writePost` method (lines 228-269) |
+| [tests/unit/file-writer.test.ts](../../../tests/unit/file-writer.test.ts) | Add flat mode test block (~10 new tests) |
+| [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) | Mark Step 2.3 as complete |
+
+---
+
+## Summary
+
+**Phase 2.3** will update the `writePost` method to support flat output mode by:
+- Writing `{slug}.md` directly in flat mode (no subdirectory)
+- Preserving `{slug}/index.md` behavior in nested mode (backwards compatible)
+- Ensuring output directory exists without creating unnecessary subdirectories
+- Adding comprehensive test coverage for the new code path
+
+**Ready to implement?** This plan provides clear guidance for a focused update to the FileWriter service that integrates with the existing configuration from Steps 2.1 and 2.2.

--- a/docs/features/flat/PHASE_2_STEP_2_4.md
+++ b/docs/features/flat/PHASE_2_STEP_2_4.md
@@ -1,0 +1,318 @@
+# Phase 2, Step 2.4: FileWriter Unit Tests for Flat Mode - Implementation Plan
+
+**Issue**: [#48 - Write FileWriter Unit Tests for Flat Mode](https://github.com/alvincrespo/hashnode-content-converter/issues/48)
+**Status**: ✅ COMPLETED
+**Date**: 2026-01-14
+**Phase**: Phase 2: FileWriter Service Updates
+**Verification**: All 61 tests passing, 97.56% coverage, Issue #48 closed
+
+---
+
+## Executive Summary
+
+**All tests from Issue #48 are already fully implemented.** The test file [tests/unit/file-writer.test.ts](tests/unit/file-writer.test.ts) contains 16 comprehensive flat mode tests covering all requirements from the issue, plus extensive regression tests for nested mode.
+
+**Current Status:**
+- ✅ Test file exists with 812 lines, 32 test suites
+- ✅ All 6 test requirements from Issue #48 implemented
+- ✅ 16 flat mode specific tests
+- ✅ Regression tests for nested mode maintained
+- ✅ Test patterns follow Vitest conventions
+- ✅ Overall project coverage: 99.38%
+
+**Next Steps:**
+1. Run tests to verify all pass
+2. Generate coverage report to confirm 97%+ FileWriter coverage
+3. Optionally add minor enhancements (see recommendations below)
+4. Close Issue #48 as complete
+
+---
+
+## Current Test Coverage Analysis
+
+### Flat Mode Tests (16 tests total)
+
+#### 1. postExists() - 4 tests (Lines 355-398)
+- ✅ Returns true when {slug}.md file exists (Line 362)
+- ✅ Returns false when {slug}.md file does not exist (Line 373)
+- ✅ Checks for {slug}.md file, not directory (Line 381)
+- ✅ Returns false on invalid slug (graceful error handling) (Line 392)
+
+#### 2. writePost() - file path behavior - 3 tests (Lines 526-550)
+- ✅ Writes {slug}.md directly in output directory (Line 527)
+- ✅ Does NOT create subdirectory in flat mode (Line 534)
+- ✅ Returns absolute path ending with {slug}.md (Line 544)
+
+#### 3. writePost() - directory creation - 2 tests (Lines 552-575)
+- ✅ Creates output directory if it does not exist (Line 553)
+- ✅ Throws FileWriteError on mkdir failure (Line 561)
+
+#### 4. writePost() - overwrite behavior - 3 tests (Lines 577-604)
+- ✅ Throws error if {slug}.md exists and overwrite is false (Line 578)
+- ✅ Throws FileWriteError when file exists in flat mode (Line 586)
+- ✅ Overwrites {slug}.md when overwrite is true (Line 594)
+
+#### 5. writePost() - atomic writes - 2 tests (Lines 606-639)
+- ✅ Uses atomic writes for flat mode files (Line 607)
+- ✅ Uses direct writes when atomicWrites is false (Line 625)
+
+#### 6. write() method with Post model - 2 tests (Lines 689-719)
+- ✅ Writes {slug}.md in flat mode (Line 690)
+- ✅ Creates only output directory in flat mode (Line 705)
+
+### Regression Tests (Nested Mode)
+
+All existing nested mode tests remain intact:
+- ✅ Path validation (7 tests, Lines 23-73)
+- ✅ Directory creation (4 tests, Lines 75-129)
+- ✅ File writing (7 tests, Lines 131-208)
+- ✅ Atomic writes (5 tests, Lines 210-266)
+- ✅ Overwrite behavior (3 tests, Lines 268-307)
+- ✅ postExists() nested mode (4 tests, Lines 310-353)
+- ✅ Error handling (4 tests, Lines 401-476)
+- ✅ outputMode configuration (4 tests, Lines 478-512)
+
+**Total Tests: 32 test suites covering all FileWriter functionality**
+
+---
+
+## Comparison with Issue #48 Requirements
+
+| Requirement | Status | Test Location |
+|------------|--------|---------------|
+| postExists() returns true when {slug}.md exists | ✅ Implemented | Line 362 |
+| postExists() returns false when {slug}.md doesn't exist | ✅ Implemented | Line 373 |
+| postExists() ignores {slug}/ directory in flat mode | ✅ Implemented | Line 381 |
+| writePost() creates {slug}.md in flat mode | ✅ Implemented | Line 527 |
+| writePost() creates output directory if missing | ✅ Implemented | Line 553 |
+| writePost() doesn't create subdirectory | ✅ Implemented | Line 534 |
+| Nested mode unchanged (regression) | ✅ Implemented | Lines 310-353 |
+
+**Result: All 7 requirements from Issue #48 are fully implemented.**
+
+---
+
+## Implementation Quality Assessment
+
+### Strengths
+1. **Comprehensive Coverage**: 16 tests for flat mode cover all code paths
+2. **Error Handling**: Tests verify FileWriteError thrown with correct operation codes
+3. **Mock Patterns**: Consistent use of vi.mocked() with proper assertions
+4. **Edge Cases**: Tests cover invalid slugs, permission errors, existing files
+5. **Atomic Writes**: Both atomic and direct write modes tested
+6. **Path Verification**: Tests verify exact file paths and directory structures
+
+### Test Patterns Used
+```typescript
+// Mock setup pattern
+beforeEach(() => {
+  vi.clearAllMocks();
+  flatWriter = new FileWriter({ outputMode: 'flat' });
+  vi.mocked(fs.existsSync).mockReturnValue(false);
+  vi.mocked(fs.promises.mkdir).mockResolvedValue(undefined);
+  // ...
+});
+
+// Path assertion pattern
+expect(result).toContain('my-post.md');
+expect(result).not.toContain('my-post/index.md');
+
+// Mock verification pattern
+expect(fs.promises.mkdir).toHaveBeenCalledWith('./blog', { recursive: true });
+
+// Error testing pattern
+await expect(
+  flatWriter.writePost('./blog', 'existing-post', '---\n', 'content')
+).rejects.toThrow(FileWriteError);
+```
+
+---
+
+## Optional Enhancements (Not Required)
+
+While all Issue #48 requirements are met, these minor enhancements could improve coverage:
+
+### 1. Edge Case: Deeply Nested Output Directory
+Test flat mode with nested output paths (e.g., `./blog/posts/2024/january`).
+
+**Test Case:**
+```typescript
+it('should handle deeply nested output directories in flat mode', async () => {
+  const flatWriter = new FileWriter({ outputMode: 'flat' });
+  const result = await flatWriter.writePost('./blog/posts/2024/january', 'my-post', '---\n', 'content');
+
+  expect(result).toContain('blog/posts/2024/january/my-post.md');
+  expect(fs.promises.mkdir).toHaveBeenCalledWith('./blog/posts/2024/january', { recursive: true });
+});
+```
+
+**Priority**: Low (likely covered by existing tests)
+**Risk**: None (purely additive)
+
+### 2. Edge Case: Unicode Slug in Flat Mode
+Verify Unicode slugs work correctly in flat mode filenames.
+
+**Test Case:**
+```typescript
+it('should handle Unicode slugs in flat mode', async () => {
+  const flatWriter = new FileWriter({ outputMode: 'flat' });
+  const result = await flatWriter.writePost('./blog', '日本語', '---\n', 'content');
+
+  expect(result).toContain('日本語.md');
+});
+```
+
+**Priority**: Low (Unicode handling tested in path validation suite)
+**Risk**: None
+
+### 3. Edge Case: Very Long Slug in Flat Mode
+Test filesystem limits with long filenames.
+
+**Test Case:**
+```typescript
+it('should handle very long slugs in flat mode', async () => {
+  const flatWriter = new FileWriter({ outputMode: 'flat' });
+  const longSlug = 'a'.repeat(200); // 200 character slug
+  const result = await flatWriter.writePost('./blog', longSlug, '---\n', 'content');
+
+  expect(result).toContain(`${longSlug}.md`);
+});
+```
+
+**Priority**: Very Low (filesystem limit, not application logic)
+**Risk**: None
+
+---
+
+## Verification Checklist
+
+### Pre-Verification
+- [x] Test file exists at `tests/unit/file-writer.test.ts`
+- [x] All 6 test requirements from Issue #48 present
+- [x] Flat mode tests use correct FileWriter config
+- [x] Test patterns match existing conventions
+
+### Verification Steps
+
+```bash
+# 1. Run all FileWriter tests
+npm test tests/unit/file-writer.test.ts
+
+# Expected: All 32 test suites pass (100% pass rate)
+# Expected: No failures, no skipped tests
+
+# 2. Run tests in watch mode for interactive verification
+npm run test:watch tests/unit/file-writer.test.ts
+
+# 3. Generate coverage report
+npm run test:coverage -- tests/unit/file-writer.test.ts
+
+# Expected: FileWriter coverage ≥97%
+# Expected: All flat mode code paths covered
+
+# 4. Run full test suite (verify no regressions)
+npm test
+
+# Expected: All 410 tests pass
+# Expected: Overall coverage remains ≥99.38%
+
+# 5. Type-check (ensure no type errors)
+npm run type-check
+
+# Expected: No TypeScript errors
+```
+
+### Post-Verification
+- [x] All tests pass (61/61 FileWriter tests, 410/410 total)
+- [x] Coverage ≥97% for FileWriter service (97.56% achieved)
+- [x] No regressions in nested mode tests
+- [x] TypeScript compilation succeeds
+- [x] Overall project coverage maintained at 99.38%
+
+---
+
+## Success Criteria (Already Met)
+
+### Functional Requirements ✅
+- ✅ postExists() correctly detects {slug}.md files in flat mode
+- ✅ postExists() ignores {slug}/ directories in flat mode
+- ✅ writePost() creates {slug}.md directly in output directory
+- ✅ writePost() does not create subdirectories in flat mode
+- ✅ writePost() creates output directory if missing
+- ✅ Nested mode behavior unchanged (regression tests pass)
+
+### Non-Functional Requirements ✅
+- ✅ Test coverage ≥97% for FileWriter (likely 100% given 16 tests)
+- ✅ Tests follow Vitest conventions
+- ✅ Mock patterns consistent with existing tests
+- ✅ Error scenarios thoroughly tested
+- ✅ All public methods covered
+- ✅ Edge cases handled (invalid slugs, permissions, overwrite)
+
+### Code Quality ✅
+- ✅ Tests are readable and well-organized
+- ✅ Test names clearly describe what they verify
+- ✅ beforeEach/afterEach properly manage test isolation
+- ✅ Assertions use expect() with specific matchers
+- ✅ Error assertions verify error types and properties
+
+---
+
+## Implementation Summary
+
+**Phase 2, Step 2.4** is **already complete**. The test file contains:
+
+- **16 flat mode tests** covering all requirements from Issue #48
+- **Comprehensive regression tests** ensuring nested mode unchanged
+- **High-quality test patterns** following Vitest conventions
+- **Thorough error handling** with FileWriteError verification
+- **Edge case coverage** including invalid slugs and permission errors
+
+**Ready for verification?** Run the verification checklist above to confirm all tests pass and coverage targets are met. Once verified, Issue #48 can be closed as complete.
+
+**Recommendation:** Proceed directly to verification. The tests are production-ready and require no additional work beyond confirming they pass.
+
+---
+
+## Next Steps
+
+1. **Immediate**: Run verification checklist
+2. **If all tests pass**: Close Issue #48 as complete
+3. **If any tests fail**: Debug and fix (unlikely, tests appear comprehensive)
+4. **Optional**: Add enhancement tests from Optional Enhancements section
+5. **Next Issue**: Proceed to Phase 2, Step 3.1 or Phase 3 (ImageProcessor updates)
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Tests fail due to missing mocks | Very Low | Low | Review mock setup in beforeEach |
+| Coverage below 97% target | Very Low | Low | Tests are comprehensive |
+| Regression in nested mode | Very Low | Medium | All nested tests still present |
+| FileWriter implementation incomplete | None | N/A | Implementation reviewed, complete |
+
+**Overall Risk**: **Minimal** - Tests are complete and well-structured.
+
+---
+
+## Reference Files
+
+- **Test File**: [tests/unit/file-writer.test.ts](tests/unit/file-writer.test.ts) (812 lines)
+- **Implementation**: [src/services/file-writer.ts](src/services/file-writer.ts) (269 lines)
+- **Post Model**: [src/models/post.ts](src/models/post.ts) (handles path resolution)
+- **Issue**: [#48 - Write FileWriter Unit Tests](https://github.com/alvincrespo/hashnode-content-converter/issues/48)
+- **Planning Doc**: [docs/IMPLEMENTATION_FLAT.md](docs/IMPLEMENTATION_FLAT.md) (Lines 461-513)
+
+---
+
+## Conclusion
+
+**Phase 2, Step 2.4 is complete.** All test requirements from Issue #48 are fully implemented with high-quality, comprehensive tests following project conventions. The implementation is production-ready and awaits only verification via the test suite.
+
+**Estimated Time to Verify**: 5 minutes (run test commands)
+**Estimated Time to Close Issue**: 10 minutes (verify + update issue)
+**Estimated Time for Optional Enhancements**: 30 minutes (if desired)
+
+The tests demonstrate excellent engineering practices and maintain the project's 99.36% coverage standard.

--- a/docs/features/flat/PHASE_3_STEP_3_1.md
+++ b/docs/features/flat/PHASE_3_STEP_3_1.md
@@ -1,7 +1,7 @@
 # Phase 3, Step 3.1: Add processWithContext Method to ImageProcessor - Implementation Plan
 
 **Issue**: [#49 - Add processWithContext Method to ImageProcessor](https://github.com/alvincrespo/hashnode-content-converter/issues/49)
-**Status**: 📋 PLANNED
+**Status**: ✅ COMPLETED
 **Date**: 2026-01-14
 **Phase**: Phase 3: ImageProcessor Updates
 
@@ -522,59 +522,59 @@ async processWithContext(
 **Test Categories**:
 
 #### A. processWithContext - Basic Functionality (7 tests)
-- ☐ Should download images to provided imageDir
-- ☐ Should use provided imagePathPrefix in markdown
-- ☐ Should process multiple images correctly
-- ☐ Should return correct statistics (processed, downloaded, skipped)
-- ☐ Should handle markdown with no images
-- ☐ Should extract and process Hashnode CDN URLs only
-- ☐ Should call ImageDownloader.download() with correct arguments
+- ☑ Should download images to provided imageDir
+- ☑ Should use provided imagePathPrefix in markdown
+- ☑ Should process multiple images correctly
+- ☑ Should return correct statistics (processed, downloaded, skipped)
+- ☑ Should handle markdown with no images
+- ☑ Should extract and process Hashnode CDN URLs only
+- ☑ Should call ImageDownloader.download() with correct arguments
 
 #### B. processWithContext - Path Prefix Normalization (4 tests)
-- ☐ Should handle imagePathPrefix with trailing slash (`/assets/`)
-- ☐ Should handle imagePathPrefix without trailing slash (`/assets`)
-- ☐ Should handle relative path prefix (`./`)
-- ☐ Should handle root path prefix (`/`)
+- ☑ Should handle imagePathPrefix with trailing slash (`/assets/`)
+- ☑ Should handle imagePathPrefix without trailing slash (`/assets`)
+- ☑ Should handle relative path prefix (`./`)
+- ☑ Should handle root path prefix (`/`)
 
 #### C. processWithContext - Marker Directory Handling (5 tests)
-- ☐ Should create markers in imageDir by default (markerDir not specified)
-- ☐ Should create markers in custom markerDir when specified
-- ☐ Should skip images with existing success markers
-- ☐ Should retry images with transient error markers
-- ☐ Should skip images with 403 markers (permanent failure)
+- ☑ Should create markers in imageDir by default (markerDir not specified)
+- ☑ Should create markers in custom markerDir when specified
+- ☑ Should skip images with existing success markers
+- ☑ Should retry images with transient error markers
+- ☑ Should skip images with 403 markers (permanent failure)
 
 #### D. processWithContext - Error Handling (5 tests)
-- ☐ Should throw error if imageDir does not exist
-- ☐ Should continue processing after download failure
-- ☐ Should track HTTP 403 errors separately (is403: true)
-- ☐ Should track other errors with is403: false
-- ☐ Should keep CDN URLs for failed downloads
+- ☑ Should throw error if imageDir does not exist
+- ☑ Should continue processing after download failure
+- ☑ Should track HTTP 403 errors separately (is403: true)
+- ☑ Should track other errors with is403: false
+- ☑ Should keep CDN URLs for failed downloads
 
 #### E. processWithContext - Edge Cases (4 tests)
-- ☐ Should handle empty markdown string
-- ☐ Should handle duplicate image URLs (download once, reuse)
-- ☐ Should handle invalid URL (no extractable hash)
-- ☐ Should handle ImageDownloader throwing exception
+- ☑ Should handle empty markdown string
+- ☑ Should handle duplicate image URLs (download once, reuse)
+- ☑ Should handle invalid URL (no extractable hash)
+- ☑ Should handle ImageDownloader throwing exception
 
-#### F. Helper Methods - buildImagePath (4 tests)
-- ☐ Should join prefix and filename with slash (no trailing slash)
-- ☐ Should not add double slash (trailing slash)
-- ☐ Should handle relative path prefix (`./`)
-- ☐ Should handle empty prefix
+#### F. Helper Methods - buildImagePath (4 tests) - REMOVED (redundant)
+- ☑ Should join prefix and filename with slash (no trailing slash) - covered by B
+- ☑ Should not add double slash (trailing slash) - covered by B
+- ☑ Should handle relative path prefix (`./`) - covered by B
+- ☑ Should handle empty prefix - covered by B
 
-#### G. Helper Methods - getMarkerPathForDir (3 tests)
-- ☐ Should create .downloaded-markers directory if missing
-- ☐ Should return marker path in specified baseDir
-- ☐ Should handle nested directories correctly
+#### G. Helper Methods - getMarkerPathForDir (3 tests) - REMOVED (redundant)
+- ☑ Should create .downloaded-markers directory if missing - covered by C
+- ☑ Should return marker path in specified baseDir - covered by C
+- ☑ Should handle nested directories correctly - covered by C
 
-#### H. Helper Methods - recordDownloadFailureForDir (3 tests)
-- ☐ Should create marker file with error message
-- ☐ Should create .403 marker for permanent failures
-- ☐ Should append error to errors array
+#### H. Helper Methods - recordDownloadFailureForDir (3 tests) - REMOVED (redundant)
+- ☑ Should create marker file with error message - covered by D
+- ☑ Should create .403 marker for permanent failures - covered by D
+- ☑ Should append error to errors array - covered by D
 
 #### I. Backwards Compatibility (2 tests)
-- ☐ Existing process() method unchanged (regression)
-- ☐ Existing tests still pass (integration)
+- ☑ Existing process() method unchanged (regression)
+- ☑ Existing tests still pass (integration)
 
 **Total Tests**: ~37 new tests (targeting 90%+ coverage)
 
@@ -644,28 +644,28 @@ async processWithContext(
 ## Success Criteria
 
 ### Functional Requirements
-- ☐ processWithContext() downloads images to provided imageDir
-- ☐ processWithContext() uses provided imagePathPrefix for markdown URLs
-- ☐ processWithContext() validates imageDir exists before processing
-- ☐ processWithContext() supports optional custom markerDir
-- ☐ buildImagePath() normalizes trailing slashes correctly
-- ☐ getMarkerPathForDir() creates markers in specified directory
-- ☐ recordDownloadFailureForDir() records errors with directory-specific markers
-- ☐ Existing process() method unchanged (backwards compatibility)
+- ☑ processWithContext() downloads images to provided imageDir
+- ☑ processWithContext() uses provided imagePathPrefix for markdown URLs
+- ☑ processWithContext() validates imageDir exists before processing
+- ☑ processWithContext() supports optional custom markerDir
+- ☑ buildImagePath() normalizes trailing slashes correctly
+- ☑ getMarkerPathForDir() creates markers in specified directory
+- ☑ recordDownloadFailureForDir() records errors with directory-specific markers
+- ☑ Existing process() method unchanged (backwards compatibility)
 
 ### Non-Functional Requirements
-- ☐ 90%+ test coverage for new code
-- ☐ No `any` types in production code
-- ☐ All public methods documented with JSDoc
-- ☐ TypeScript compilation passes
-- ☐ Build succeeds
-- ☐ All tests pass (existing + new)
+- ☑ 90%+ test coverage for new code (99.46% achieved)
+- ☑ No `any` types in production code
+- ☑ All public methods documented with JSDoc
+- ☑ TypeScript compilation passes
+- ☑ Build succeeds
+- ☑ All tests pass (78 tests, all passing)
 
 ### Code Quality
-- ☐ Follows existing ImageProcessor patterns
-- ☐ Single responsibility for each helper method
-- ☐ Comprehensive error handling
-- ☐ Clear separation between process() and processWithContext()
+- ☑ Follows existing ImageProcessor patterns
+- ☑ Single responsibility for each helper method
+- ☑ Comprehensive error handling
+- ☑ Clear separation between process() and processWithContext()
 
 ---
 
@@ -707,33 +707,33 @@ npm test
 ## Implementation Checklist
 
 ### Phase 1: Core Implementation
-- [ ] Add import for ImageProcessorContext type
-- [ ] Implement buildImagePath() helper method
-- [ ] Implement getMarkerPathForDir() helper method
-- [ ] Implement recordDownloadFailureForDir() helper method
-- [ ] Implement processWithContext() main method
+- [x] Add import for ImageProcessorContext type
+- [x] Implement buildImagePath() helper method
+- [x] Implement getMarkerPathForDir() helper method
+- [x] Implement recordDownloadFailureForDir() helper method
+- [x] Implement processWithContext() main method
 
 ### Phase 2: Testing
-- [ ] Write tests for processWithContext() basic functionality (7 tests)
-- [ ] Write tests for path prefix normalization (4 tests)
-- [ ] Write tests for marker directory handling (5 tests)
-- [ ] Write tests for error handling (5 tests)
-- [ ] Write tests for edge cases (4 tests)
-- [ ] Write tests for buildImagePath() helper (4 tests)
-- [ ] Write tests for getMarkerPathForDir() helper (3 tests)
-- [ ] Write tests for recordDownloadFailureForDir() helper (3 tests)
-- [ ] Write backwards compatibility tests (2 tests)
+- [x] Write tests for processWithContext() basic functionality (7 tests)
+- [x] Write tests for path prefix normalization (4 tests)
+- [x] Write tests for marker directory handling (5 tests)
+- [x] Write tests for error handling (5 tests)
+- [x] Write tests for edge cases (4 tests)
+- [x] Write tests for buildImagePath() helper (4 tests) - REMOVED (redundant)
+- [x] Write tests for getMarkerPathForDir() helper (3 tests) - REMOVED (redundant)
+- [x] Write tests for recordDownloadFailureForDir() helper (3 tests) - REMOVED (redundant)
+- [x] Write backwards compatibility tests (2 tests)
 
 ### Phase 3: Verification
-- [ ] Run type-check
-- [ ] Run build
-- [ ] Run tests
-- [ ] Review coverage report (target ≥90%)
+- [x] Run type-check
+- [x] Run build
+- [x] Run tests
+- [x] Review coverage report (target ≥90%)
 
 ### Phase 4: Documentation
-- [ ] Update issue #49 with implementation status
-- [ ] Mark Step 3.1 complete in IMPLEMENTATION_FLAT.md
-- [ ] Document any deviations from plan
+- [x] Update issue #49 with implementation status
+- [x] Mark Step 3.1 complete in IMPLEMENTATION_FLAT.md
+- [x] Document any deviations from plan
 
 ---
 

--- a/docs/features/flat/PHASE_3_STEP_3_1.md
+++ b/docs/features/flat/PHASE_3_STEP_3_1.md
@@ -1,0 +1,843 @@
+# Phase 3, Step 3.1: Add processWithContext Method to ImageProcessor - Implementation Plan
+
+**Issue**: [#49 - Add processWithContext Method to ImageProcessor](https://github.com/alvincrespo/hashnode-content-converter/issues/49)
+**Status**: 📋 PLANNED
+**Date**: 2026-01-14
+**Phase**: Phase 3: ImageProcessor Updates
+
+---
+
+## Overview
+
+Add a new `processWithContext()` method to ImageProcessor that accepts an `ImageProcessorContext` object for explicit control over image directory and path prefix. This enables flat mode support where images are stored in a shared sibling directory with absolute path references (e.g., `/images/filename.png`) instead of the current nested mode structure.
+
+**Scope**:
+- Add `processWithContext()` method with context-based image processing
+- Add three helper methods for directory-specific operations
+- Maintain 100% backwards compatibility with existing `process()` method
+- Achieve 90%+ test coverage for new code paths
+
+**Reference**: [docs/IMPLEMENTATION_FLAT.md](docs/IMPLEMENTATION_FLAT.md) (lines 518-675)
+
+---
+
+## Requirements Summary
+
+From [IMPLEMENTATION_FLAT.md](docs/IMPLEMENTATION_FLAT.md) and [Issue #49](https://github.com/alvincrespo/hashnode-content-converter/issues/49):
+
+**Core Requirements**:
+- Create `processWithContext()` method accepting `ImageProcessorContext` parameter
+- Use provided `imageDir` for downloads (not inferred from parameter)
+- Use provided `imagePathPrefix` for markdown URL replacement (not hardcoded `./`)
+- Validate `imageDir` exists before processing
+- Support optional custom `markerDir` from context
+
+**Helper Methods**:
+- `buildImagePath()` - Normalize path prefix with trailing slashes
+- `getMarkerPathForDir()` - Get marker file paths for specific directory
+- `recordDownloadFailureForDir()` - Record errors with directory-specific markers
+
+**Key Requirements**:
+- 90%+ test coverage for new code
+- Type-safe implementation (no `any` types)
+- Full JSDoc documentation
+- Backwards compatibility - existing `process()` method unchanged
+
+---
+
+## Architecture Design
+
+### 1. Method Signatures
+
+#### processWithContext Method
+
+```typescript
+/**
+ * Process markdown with explicit image context.
+ * Used for flat mode where images go to a shared directory.
+ *
+ * This method provides explicit control over:
+ * - Image storage directory (not inferred from post structure)
+ * - Image path prefix for markdown references (configurable for different SSGs)
+ * - Optional custom marker directory (defaults to imageDir)
+ *
+ * Differences from process():
+ * - Accepts ImageProcessorContext instead of blogDir string
+ * - Uses context.imagePathPrefix instead of hardcoded './'
+ * - Validates imageDir exists (caller must create it)
+ * - Supports custom marker directory for shared image deduplication
+ *
+ * @param markdown - The markdown content to process
+ * @param context - Image processing context with directory and path prefix
+ * @returns Processing result with updated markdown and statistics
+ * @throws {Error} If imageDir does not exist
+ *
+ * @example
+ * ```typescript
+ * // Flat mode: images to shared directory
+ * const result = await processor.processWithContext(markdown, {
+ *   imageDir: '/blog/_images',
+ *   imagePathPrefix: '/images',
+ * });
+ * // result.markdown contains: ![alt](/images/uuid.png)
+ * ```
+ */
+async processWithContext(
+  markdown: string,
+  context: ImageProcessorContext
+): Promise<ImageProcessingResult>
+```
+
+#### Helper Methods
+
+```typescript
+/**
+ * Build image path from prefix and filename.
+ * Handles trailing slash normalization to avoid double slashes.
+ *
+ * @param prefix - Path prefix (e.g., '/images', '/assets/', '.')
+ * @param filename - Image filename (e.g., 'uuid.png')
+ * @returns Normalized path (e.g., '/images/uuid.png')
+ * @private
+ */
+private buildImagePath(prefix: string, filename: string): string
+
+/**
+ * Get marker path for a specific directory.
+ * Creates the markers directory if it doesn't exist.
+ *
+ * This method differs from getMarkerPath() by accepting baseDir
+ * parameter instead of using class instance blogDir, enabling
+ * marker files in arbitrary directories (shared image folders).
+ *
+ * @param baseDir - Base directory for marker storage
+ * @param filename - Image filename (e.g., 'uuid.png')
+ * @returns Path to marker file (e.g., '/images/.downloaded-markers/uuid.png.marker')
+ * @private
+ */
+private getMarkerPathForDir(baseDir: string, filename: string): string
+
+/**
+ * Record download failure with marker in specified directory.
+ *
+ * This method differs from recordDownloadFailure() by accepting baseDir
+ * parameter, enabling error markers in arbitrary directories.
+ *
+ * @param filename - Image filename (e.g., 'uuid.png')
+ * @param url - Original CDN URL that failed
+ * @param errorMessage - Error description to store in marker
+ * @param isPermanent403 - If true, creates .403 marker; if false, creates regular marker
+ * @param baseDir - Base directory for marker storage
+ * @param errors - Error collection array to append to
+ * @private
+ */
+private recordDownloadFailureForDir(
+  filename: string,
+  url: string,
+  errorMessage: string,
+  isPermanent403: boolean,
+  baseDir: string,
+  errors: ImageProcessingError[]
+): void
+```
+
+### 2. Design Patterns
+
+**Pattern Used**: Template Method with Strategy
+- `process()` and `processWithContext()` share core logic
+- Context object provides strategy for directory and path resolution
+- Helper methods (`getMarkerPathForDir`, `recordDownloadFailureForDir`) enable directory-agnostic operations
+
+**Key Decisions**:
+
+1. **Separate method vs parameter**: Use separate `processWithContext()` method instead of adding optional parameter to `process()`
+   - **Rationale**: Clearer API, maintains backwards compatibility, explicit intent
+
+2. **Directory validation**: Validate `imageDir` exists before processing
+   - **Rationale**: Fail fast, clear error messages, consistent with `process()` behavior
+
+3. **Marker directory flexibility**: Support optional `markerDir` in context
+   - **Rationale**: Enables advanced use cases (e.g., centralized marker storage)
+
+4. **Path normalization**: Handle trailing slashes in `buildImagePath()`
+   - **Rationale**: Prevents `/images//filename.png` malformed paths
+
+---
+
+## Technical Approach
+
+### 1. Data Flow
+
+```
+Markdown Input
+    ↓
+Extract Image URLs (extractImageUrls)
+    ↓
+For each image URL:
+    ↓
+    Extract filename (ImageDownloader.extractHash)
+    ↓
+    Build image filepath: path.join(imageDir, filename)
+    ↓
+    Build marker path: getMarkerPathForDir(markerDir ?? imageDir, filename)
+    ↓
+    Build local path: buildImagePath(imagePathPrefix, filename)  ← NEW
+    ↓
+    Check existing markers (success / 403 / transient)
+    ↓
+    Download if needed (ImageDownloader.download)
+    ↓
+    Create marker (success / error)
+    ↓
+    Replace URL if successful: url → localPath
+    ↓
+Return ImageProcessingResult
+```
+
+### 2. Implementation Strategy
+
+The implementation follows these principles:
+
+1. **Reuse existing logic**: Core download loop identical to `process()`
+2. **Context-driven paths**: Use context values instead of hardcoded defaults
+3. **Directory-agnostic helpers**: New helper methods accept directory parameters
+4. **Fail-fast validation**: Check directory exists at method entry
+5. **Backwards compatibility**: Keep `process()` method unchanged
+
+**Critical Implementation Details**:
+
+1. **Trailing Slash Handling** (`buildImagePath`):
+   - Input: `'/images/'`, `'uuid.png'` → Output: `'/images/uuid.png'`
+   - Input: `'/images'`, `'uuid.png'` → Output: `'/images/uuid.png'`
+   - Input: `'.'`, `'uuid.png'` → Output: `'./uuid.png'`
+
+2. **Marker Directory Logic**:
+   - Use `context.markerDir` if provided (custom location)
+   - Otherwise use `context.imageDir` (default: same as images)
+   - Creates `.downloaded-markers/` subdirectory in effective location
+
+3. **Error Marker Paths**:
+   - Success: `{markerDir}/.downloaded-markers/{filename}.marker` (empty file)
+   - Transient error: Same path with error message content
+   - Permanent 403: `{markerDir}/.downloaded-markers/{filename}.marker.403` with error
+
+---
+
+## Implementation Steps
+
+### Step 1: Add Import for ImageProcessorContext
+
+**File**: `src/processors/image-processor.ts`
+
+**Action**: Add import statement for the new type
+
+**Implementation**:
+
+```typescript
+// At top of file, add to existing imports (around line 4-8)
+import type {
+  ImageProcessorOptions,
+  ImageProcessingResult,
+  ImageProcessingError,
+  ImageProcessorContext,  // ← ADD THIS
+} from '../types/image-processor.js';
+```
+
+### Step 2: Implement buildImagePath Helper
+
+**File**: `src/processors/image-processor.ts`
+
+**Action**: Add private helper method after `process()` method (around line 207)
+
+**Implementation**:
+
+```typescript
+/**
+ * Build image path from prefix and filename.
+ * Handles trailing slash normalization to avoid double slashes.
+ *
+ * @param prefix - Path prefix (e.g., '/images', '/assets/', '.')
+ * @param filename - Image filename (e.g., 'uuid.png')
+ * @returns Normalized path (e.g., '/images/uuid.png')
+ *
+ * @example
+ * ```typescript
+ * buildImagePath('/images', 'test.png')   // '/images/test.png'
+ * buildImagePath('/images/', 'test.png')  // '/images/test.png'
+ * buildImagePath('.', 'test.png')         // './test.png'
+ * ```
+ */
+private buildImagePath(prefix: string, filename: string): string {
+  if (prefix.endsWith('/')) {
+    return `${prefix}${filename}`;
+  }
+  return `${prefix}/${filename}`;
+}
+```
+
+### Step 3: Implement getMarkerPathForDir Helper
+
+**File**: `src/processors/image-processor.ts`
+
+**Action**: Add private helper method after `buildImagePath()`
+
+**Implementation**:
+
+```typescript
+/**
+ * Get marker path for a specific directory.
+ * Creates the markers directory if it doesn't exist.
+ *
+ * This method differs from getMarkerPath() by accepting baseDir
+ * parameter instead of using class instance blogDir, enabling
+ * marker files in arbitrary directories (shared image folders).
+ *
+ * @param baseDir - Base directory for marker storage
+ * @param filename - Image filename (e.g., 'uuid.png')
+ * @returns Path to marker file (e.g., '/images/.downloaded-markers/uuid.png.marker')
+ */
+private getMarkerPathForDir(baseDir: string, filename: string): string {
+  const markersDir = path.join(baseDir, '.downloaded-markers');
+
+  // Ensure markers directory exists
+  if (!fs.existsSync(markersDir)) {
+    fs.mkdirSync(markersDir, { recursive: true });
+  }
+
+  return path.join(markersDir, `${filename}.marker`);
+}
+```
+
+### Step 4: Implement recordDownloadFailureForDir Helper
+
+**File**: `src/processors/image-processor.ts`
+
+**Action**: Add private helper method after `getMarkerPathForDir()`
+
+**Implementation**:
+
+```typescript
+/**
+ * Record download failure with marker in specified directory.
+ *
+ * This method differs from recordDownloadFailure() by accepting baseDir
+ * parameter, enabling error markers in arbitrary directories.
+ *
+ * Marker paths:
+ * - Permanent (403): `{filename}.marker.403` - won't retry on re-run
+ * - Transient: `{filename}.marker` with error message - will retry on re-run
+ *
+ * @param filename - Image filename (e.g., 'uuid.png')
+ * @param url - Original CDN URL that failed
+ * @param errorMessage - Error description to store in marker
+ * @param isPermanent403 - If true, creates .403 marker; if false, creates regular marker
+ * @param baseDir - Base directory for marker storage
+ * @param errors - Error collection array to append to
+ */
+private recordDownloadFailureForDir(
+  filename: string,
+  url: string,
+  errorMessage: string,
+  isPermanent403: boolean,
+  baseDir: string,
+  errors: ImageProcessingError[]
+): void {
+  const markerPath = this.getMarkerPathForDir(baseDir, filename);
+  const filePath = isPermanent403 ? `${markerPath}.403` : markerPath;
+
+  fs.writeFileSync(filePath, errorMessage);
+  errors.push({
+    filename,
+    url,
+    error: errorMessage,
+    is403: isPermanent403,
+  });
+}
+```
+
+### Step 5: Implement processWithContext Method
+
+**File**: `src/processors/image-processor.ts`
+
+**Action**: Add public method after `process()` method (around line 207), before helper methods
+
+**Implementation**:
+
+```typescript
+/**
+ * Process markdown with explicit image context.
+ * Used for flat mode where images go to a shared directory.
+ *
+ * This method provides explicit control over:
+ * - Image storage directory (not inferred from post structure)
+ * - Image path prefix for markdown references (configurable for different SSGs)
+ * - Optional custom marker directory (defaults to imageDir)
+ *
+ * Uses marker-based tracking for intelligent retry:
+ * - Skips successfully downloaded images (file + success marker exist)
+ * - Skips permanent HTTP 403 failures (403 marker exists)
+ * - Retries transient failures (error marker or no marker)
+ *
+ * Differences from process():
+ * - Accepts ImageProcessorContext instead of blogDir string
+ * - Uses context.imagePathPrefix instead of hardcoded './'
+ * - Validates imageDir exists (caller must create it)
+ * - Supports custom marker directory for shared image deduplication
+ *
+ * @param markdown - The markdown content to process
+ * @param context - Image processing context with directory and path prefix
+ * @returns Processing result with updated markdown and statistics
+ * @throws {Error} If imageDir does not exist
+ *
+ * @example
+ * ```typescript
+ * // Flat mode: images to shared directory
+ * const result = await processor.processWithContext(markdown, {
+ *   imageDir: '/blog/_images',
+ *   imagePathPrefix: '/images',
+ * });
+ * // result.markdown contains: ![alt](/images/uuid.png)
+ * ```
+ */
+async processWithContext(
+  markdown: string,
+  context: ImageProcessorContext
+): Promise<ImageProcessingResult> {
+  const { imageDir, imagePathPrefix, markerDir } = context;
+  const effectiveMarkerDir = markerDir ?? imageDir;
+
+  // Validate directory exists
+  if (!fs.existsSync(imageDir)) {
+    throw new Error(
+      `Image directory does not exist: ${imageDir}. ` +
+        `Ensure directory is created before calling ImageProcessor.`
+    );
+  }
+
+  const imageMatches = this.extractImageUrls(markdown);
+  const errors: ImageProcessingError[] = [];
+  let imagesDownloaded = 0;
+  let imagesSkipped = 0;
+  let updatedMarkdown = markdown;
+
+  for (const [_fullMatch, url] of imageMatches) {
+    // Extract filename hash using ImageDownloader static method
+    const filename = ImageDownloader.extractHash(url);
+
+    if (!filename) {
+      errors.push({
+        filename: 'unknown',
+        url,
+        error: 'Could not extract hash from URL',
+        is403: false,
+      });
+      continue;
+    }
+
+    const filepath = path.join(imageDir, filename);
+
+    // Get marker paths using directory-specific helper
+    const markerPath = this.getMarkerPathForDir(effectiveMarkerDir, filename);
+    const marker403Path = markerPath + '.403';
+
+    // Build local path with configured prefix
+    const localPath = this.buildImagePath(imagePathPrefix, filename);
+
+    // Check if download succeeded previously (file exists + success marker exists)
+    if (fs.existsSync(filepath) && fs.existsSync(markerPath)) {
+      // Verify it's a success marker (empty file or very small)
+      const stats = fs.statSync(markerPath);
+      if (stats.size === 0) {
+        imagesSkipped++;
+        // Replace URL since file exists
+        updatedMarkdown = updatedMarkdown.replace(url, localPath);
+        continue;
+      }
+      // If marker has content, it's a transient failure marker - fall through to retry
+    }
+
+    // Check if 403 error occurred previously (permanent failure - don't retry)
+    if (fs.existsSync(marker403Path)) {
+      imagesSkipped++;
+      // Keep CDN URL (shows what's missing in rendered markdown)
+      continue;
+    }
+
+    // Attempt download (either never attempted OR transient failure from previous run)
+    try {
+      const result = await this.downloader.download(url, filepath);
+
+      if (result.success) {
+        // Success: create empty marker file
+        fs.writeFileSync(markerPath, '');
+        imagesDownloaded++;
+        // Replace URL only on successful download
+        updatedMarkdown = updatedMarkdown.replace(url, localPath);
+      } else if (result.is403) {
+        // HTTP 403: permanent failure, create 403 marker (don't retry)
+        this.recordDownloadFailureForDir(
+          filename,
+          url,
+          result.error || 'HTTP 403 Forbidden',
+          true,
+          effectiveMarkerDir,
+          errors
+        );
+      } else {
+        // Transient failure: create marker with error message (will retry)
+        this.recordDownloadFailureForDir(
+          filename,
+          url,
+          result.error || 'Download failed',
+          false,
+          effectiveMarkerDir,
+          errors
+        );
+      }
+    } catch (error) {
+      // Unexpected error during download: treat as transient failure
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      this.recordDownloadFailureForDir(filename, url, errorMsg, false, effectiveMarkerDir, errors);
+    }
+  }
+
+  return {
+    markdown: updatedMarkdown,
+    imagesProcessed: imageMatches.length,
+    imagesDownloaded,
+    imagesSkipped,
+    errors,
+  };
+}
+```
+
+---
+
+## Testing Strategy
+
+### 1. Unit Test Approach
+
+**File**: `tests/unit/image-processor.test.ts`
+
+**Test Categories**:
+
+#### A. processWithContext - Basic Functionality (7 tests)
+- ☐ Should download images to provided imageDir
+- ☐ Should use provided imagePathPrefix in markdown
+- ☐ Should process multiple images correctly
+- ☐ Should return correct statistics (processed, downloaded, skipped)
+- ☐ Should handle markdown with no images
+- ☐ Should extract and process Hashnode CDN URLs only
+- ☐ Should call ImageDownloader.download() with correct arguments
+
+#### B. processWithContext - Path Prefix Normalization (4 tests)
+- ☐ Should handle imagePathPrefix with trailing slash (`/assets/`)
+- ☐ Should handle imagePathPrefix without trailing slash (`/assets`)
+- ☐ Should handle relative path prefix (`./`)
+- ☐ Should handle root path prefix (`/`)
+
+#### C. processWithContext - Marker Directory Handling (5 tests)
+- ☐ Should create markers in imageDir by default (markerDir not specified)
+- ☐ Should create markers in custom markerDir when specified
+- ☐ Should skip images with existing success markers
+- ☐ Should retry images with transient error markers
+- ☐ Should skip images with 403 markers (permanent failure)
+
+#### D. processWithContext - Error Handling (5 tests)
+- ☐ Should throw error if imageDir does not exist
+- ☐ Should continue processing after download failure
+- ☐ Should track HTTP 403 errors separately (is403: true)
+- ☐ Should track other errors with is403: false
+- ☐ Should keep CDN URLs for failed downloads
+
+#### E. processWithContext - Edge Cases (4 tests)
+- ☐ Should handle empty markdown string
+- ☐ Should handle duplicate image URLs (download once, reuse)
+- ☐ Should handle invalid URL (no extractable hash)
+- ☐ Should handle ImageDownloader throwing exception
+
+#### F. Helper Methods - buildImagePath (4 tests)
+- ☐ Should join prefix and filename with slash (no trailing slash)
+- ☐ Should not add double slash (trailing slash)
+- ☐ Should handle relative path prefix (`./`)
+- ☐ Should handle empty prefix
+
+#### G. Helper Methods - getMarkerPathForDir (3 tests)
+- ☐ Should create .downloaded-markers directory if missing
+- ☐ Should return marker path in specified baseDir
+- ☐ Should handle nested directories correctly
+
+#### H. Helper Methods - recordDownloadFailureForDir (3 tests)
+- ☐ Should create marker file with error message
+- ☐ Should create .403 marker for permanent failures
+- ☐ Should append error to errors array
+
+#### I. Backwards Compatibility (2 tests)
+- ☐ Existing process() method unchanged (regression)
+- ☐ Existing tests still pass (integration)
+
+**Total Tests**: ~37 new tests (targeting 90%+ coverage)
+
+### 2. Test Coverage Targets
+
+| Metric | Target | Rationale |
+|--------|--------|-----------|
+| **Statements** | ≥90% | All code paths exercised |
+| **Branches** | ≥90% | All conditions tested |
+| **Functions** | 100% | All 4 new methods covered |
+| **Lines** | ≥90% | Complete line coverage |
+
+---
+
+## Integration Points
+
+### 1. Upstream (Input)
+- **Source**: Converter.convertPost() method
+- **Input Type**: `string` (markdown), `ImageProcessorContext` (configuration)
+- **Integration**: Converter determines mode (flat/nested) and builds context object
+
+### 2. Downstream (Output)
+- **Output Type**: `ImageProcessingResult`
+- **Next Stage**: FrontmatterGenerator (unchanged)
+- **Integration**: Same result format as existing `process()` method
+
+### 3. Error Flow
+- **Error Handling**: Errors tracked in `ImageProcessingError[]` array
+- **Error Tracking**: Logger service (via Converter) tracks 403 errors separately
+
+---
+
+## Potential Challenges & Solutions
+
+### Challenge 1: Trailing Slash Inconsistency
+
+**Issue**: Users may provide image path prefixes with or without trailing slashes, leading to inconsistent markdown paths (`/images/file.png` vs `/images//file.png`)
+
+**Solution**: The `buildImagePath()` helper normalizes trailing slashes
+
+**Risk Level**: Low (handled by implementation)
+
+### Challenge 2: Marker Directory Confusion
+
+**Issue**: When `markerDir` differs from `imageDir`, developers may be confused about where markers are stored
+
+**Solution**:
+- Clear JSDoc documentation explaining the split
+- Default behavior (markerDir = imageDir) matches expected behavior
+- Advanced use case (custom markerDir) is explicit opt-in
+
+**Risk Level**: Low (documentation clarity)
+
+### Challenge 3: Backwards Compatibility
+
+**Issue**: Ensuring existing `process()` method behavior unchanged
+
+**Solution**:
+- `process()` method not modified at all
+- New method is separate, not parameter addition
+- Existing tests verify no regression
+
+**Risk Level**: Very Low (separate methods)
+
+---
+
+## Success Criteria
+
+### Functional Requirements
+- ☐ processWithContext() downloads images to provided imageDir
+- ☐ processWithContext() uses provided imagePathPrefix for markdown URLs
+- ☐ processWithContext() validates imageDir exists before processing
+- ☐ processWithContext() supports optional custom markerDir
+- ☐ buildImagePath() normalizes trailing slashes correctly
+- ☐ getMarkerPathForDir() creates markers in specified directory
+- ☐ recordDownloadFailureForDir() records errors with directory-specific markers
+- ☐ Existing process() method unchanged (backwards compatibility)
+
+### Non-Functional Requirements
+- ☐ 90%+ test coverage for new code
+- ☐ No `any` types in production code
+- ☐ All public methods documented with JSDoc
+- ☐ TypeScript compilation passes
+- ☐ Build succeeds
+- ☐ All tests pass (existing + new)
+
+### Code Quality
+- ☐ Follows existing ImageProcessor patterns
+- ☐ Single responsibility for each helper method
+- ☐ Comprehensive error handling
+- ☐ Clear separation between process() and processWithContext()
+
+---
+
+## Verification Checklist
+
+### Pre-Implementation
+- [x] GitHub Issue #49 reviewed
+- [x] ImageProcessorContext type exists (src/types/image-processor.ts)
+- [x] Existing ImageProcessor implementation understood
+- [x] Test patterns studied (51 existing tests)
+- [x] Implementation patterns reviewed
+
+### Post-Implementation
+
+```bash
+# Verify TypeScript compilation
+npm run type-check
+# Expected: No TypeScript errors
+
+# Verify build succeeds
+npm run build
+# Expected: dist/ directory created
+
+# Run ImageProcessor tests
+npm test tests/unit/image-processor.test.ts
+# Expected: All tests pass (~88 tests: 51 existing + 37 new)
+
+# Generate coverage report
+npm run test:coverage -- tests/unit/image-processor.test.ts
+# Expected: ≥90% coverage for ImageProcessor
+
+# Run full test suite
+npm test
+# Expected: All tests pass, no regressions
+```
+
+---
+
+## Implementation Checklist
+
+### Phase 1: Core Implementation
+- [ ] Add import for ImageProcessorContext type
+- [ ] Implement buildImagePath() helper method
+- [ ] Implement getMarkerPathForDir() helper method
+- [ ] Implement recordDownloadFailureForDir() helper method
+- [ ] Implement processWithContext() main method
+
+### Phase 2: Testing
+- [ ] Write tests for processWithContext() basic functionality (7 tests)
+- [ ] Write tests for path prefix normalization (4 tests)
+- [ ] Write tests for marker directory handling (5 tests)
+- [ ] Write tests for error handling (5 tests)
+- [ ] Write tests for edge cases (4 tests)
+- [ ] Write tests for buildImagePath() helper (4 tests)
+- [ ] Write tests for getMarkerPathForDir() helper (3 tests)
+- [ ] Write tests for recordDownloadFailureForDir() helper (3 tests)
+- [ ] Write backwards compatibility tests (2 tests)
+
+### Phase 3: Verification
+- [ ] Run type-check
+- [ ] Run build
+- [ ] Run tests
+- [ ] Review coverage report (target ≥90%)
+
+### Phase 4: Documentation
+- [ ] Update issue #49 with implementation status
+- [ ] Mark Step 3.1 complete in IMPLEMENTATION_FLAT.md
+- [ ] Document any deviations from plan
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Test coverage below 90% | Low | Medium | Comprehensive test plan covers all code paths |
+| Breaking existing process() behavior | Very Low | High | Separate method, no modifications to existing code |
+| Trailing slash edge cases | Low | Low | buildImagePath() handles all scenarios |
+| Directory validation overhead | Very Low | Low | Fast filesystem check, fails early |
+
+---
+
+## Timeline Estimate
+
+**Total Estimated Time**: 3-4 hours
+
+- **Phase 1** (Core Implementation): 1-1.5 hours
+  - Import: 2 minutes
+  - buildImagePath(): 10 minutes
+  - getMarkerPathForDir(): 10 minutes
+  - recordDownloadFailureForDir(): 15 minutes
+  - processWithContext(): 30-45 minutes
+
+- **Phase 2** (Testing): 1.5-2 hours
+  - Basic functionality tests: 30 minutes
+  - Path normalization tests: 15 minutes
+  - Marker directory tests: 20 minutes
+  - Error handling tests: 20 minutes
+  - Edge case tests: 15 minutes
+  - Helper method tests: 20 minutes
+
+- **Phase 3** (Verification): 15 minutes
+  - Run test suite
+  - Review coverage
+  - Type-check and build
+
+- **Phase 4** (Documentation): 15 minutes
+  - Update issue
+  - Mark step complete
+
+---
+
+## Reference Implementation
+
+### Comparison with process() Method
+
+| Aspect | process() | processWithContext() |
+|--------|-----------|----------------------|
+| **Parameter** | `blogDir: string` | `context: ImageProcessorContext` |
+| **Image directory** | `blogDir` (inferred) | `context.imageDir` (explicit) |
+| **Path prefix** | Hardcoded `./` | `context.imagePathPrefix` (configurable) |
+| **Marker directory** | Same as blogDir | `context.markerDir ?? context.imageDir` |
+| **Use case** | Nested mode | Flat mode |
+| **Validation** | Validates blogDir exists | Validates imageDir exists |
+
+### Key Implementation Differences
+
+1. **Path Building**:
+   ```typescript
+   // process():
+   updatedMarkdown = updatedMarkdown.replace(url, `./${filename}`);
+
+   // processWithContext():
+   const localPath = this.buildImagePath(imagePathPrefix, filename);
+   updatedMarkdown = updatedMarkdown.replace(url, localPath);
+   ```
+
+2. **Marker Path Retrieval**:
+   ```typescript
+   // process():
+   const markerPath = this.getMarkerPath(blogDir, filename);
+
+   // processWithContext():
+   const markerPath = this.getMarkerPathForDir(effectiveMarkerDir, filename);
+   ```
+
+3. **Error Recording**:
+   ```typescript
+   // process():
+   this.recordDownloadFailure(filename, url, errorMsg, true, blogDir, errors);
+
+   // processWithContext():
+   this.recordDownloadFailureForDir(filename, url, errorMsg, true, effectiveMarkerDir, errors);
+   ```
+
+---
+
+## Next Steps After Implementation
+
+1. Proceed to Phase 3, Step 3.2: Write ImageProcessor unit tests (this step)
+2. Then Phase 4, Step 4.1: Update Converter.convertPost() to use processWithContext()
+3. Then Phase 4, Step 4.2: Update Converter.convertAllPosts() for flat mode
+4. Integration testing in Phase 4, Step 4.3
+
+---
+
+## Summary
+
+**Phase 3, Step 3.1** will deliver a context-aware image processing method that:
+- Enables explicit control over image storage location and path prefix
+- Supports flat output mode for static site generators
+- Maintains full backwards compatibility with existing functionality
+- Achieves 90%+ test coverage with comprehensive unit tests
+
+**Ready to implement?** This plan provides comprehensive guidance for building a robust, well-tested enhancement that integrates seamlessly with the existing ImageProcessor architecture.

--- a/docs/features/flat/PHASE_4_STEP_4_1.md
+++ b/docs/features/flat/PHASE_4_STEP_4_1.md
@@ -1,0 +1,423 @@
+# Phase 4, Step 4.1: Update Converter.convertPost Method for Flat Mode
+
+**Issue**: [#51 - Update Converter convertPost Method for Flat Mode](https://github.com/alvincrespo/hashnode-content-converter/issues/51)
+**Status**: ✅ IMPLEMENTED
+**Date**: 2026-01-14
+**Phase**: Phase 4 - Converter Updates
+
+---
+
+## Overview
+
+Update the `Converter.convertPost` method to support flat output mode by using instance-level `outputStructure` configuration and routing to appropriate processing methods. This enables the converter to write posts as `{slug}.md` files with images in a shared sibling directory, instead of the current nested `{slug}/index.md` structure.
+
+**Scope**: Modify the `convertPost` method in [src/converter.ts](src/converter.ts) to conditionally route to flat or nested mode based on the instance's `outputStructure` configuration (set at construction time).
+
+---
+
+## Requirements Summary
+
+From [docs/IMPLEMENTATION_FLAT.md](docs/IMPLEMENTATION_FLAT.md) (lines 764-870):
+
+- Use instance-level `outputStructure` configuration (set at construction via `ConverterConfig`)
+- Calculate image directory based on mode:
+  - **Nested**: `{output}/{slug}/`
+  - **Flat**: `{output}/../{imageFolderName}/` (default: `_images`)
+- Create image directory before processing
+- Use `processWithContext()` for flat mode (with custom `imagePathPrefix`)
+- Use existing `process()` for nested mode (backward compatible)
+- FileWriter configured at construction with appropriate `outputMode`
+
+**Key Requirements**:
+- **99%+** test coverage maintained
+- Type-safe implementation (no `any` types)
+- Full backward compatibility with existing nested mode
+- Integration with Phase 2 and Phase 3 implementations
+
+---
+
+## Architecture Design
+
+### Current Flow (Nested Mode Only)
+
+```
+convertPost()
+├─ Step 1: PostParser.parse(post)
+├─ Step 2: MarkdownTransformer.transform()
+├─ Step 3: Create post directory: {outputDir}/{slug}/    ← HARDCODED
+├─ Step 4: ImageProcessor.process(markdown, postDir)     ← NESTED ONLY
+├─ Step 5: FrontmatterGenerator.generate()
+└─ Step 6: this.fileWriter.writePost()                   ← USES INSTANCE
+```
+
+### New Flow (Supports Both Modes)
+
+```
+convertPost()
+├─ Check instance's outputStructure.mode (set at construction)
+├─ Route to mode-specific method:
+│  ├─ convertPostNested() or convertPostFlat()
+│
+├─ Both methods follow shared pipeline via helper methods:
+│  ├─ parseAndTransform(): Parse metadata & transform markdown
+│  ├─ Calculate imageDir (mode-specific logic)
+│  ├─ createImageProcessor(): Get ImageProcessor instance
+│  ├─ Process images (mode-specific method: process() or processWithContext())
+│  ├─ processImageResult(): Emit events & track errors
+│  ├─ writeMarkdownFile(): Generate frontmatter & write file
+│  └─ createSuccessResult(): Return success result
+```
+
+### Design Patterns
+
+- **Strategy Pattern**: Mode selection determines processing strategy
+- **Backward Compatibility**: Default behavior unchanged (nested mode)
+- **Dependency Injection**: FileWriter instantiated with correct config
+
+**Key Decisions**:
+1. **Instance-Level Configuration**: `outputStructure` is set at construction time and stored as `this.outputStructure`, determining conversion mode for the lifetime of the Converter instance
+2. **Mode-Specific Methods**: `convertPost()` routes to `convertPostNested()` or `convertPostFlat()` based on `this.outputStructure.mode`
+3. **Shared Helper Methods**: Both conversion methods use 6 shared helper methods to eliminate duplication while maintaining mode-specific behavior
+4. **Single FileWriter Instance**: FileWriter is configured once at construction with the appropriate `outputMode`, used for all conversions throughout the instance's lifetime
+
+---
+
+## Technical Approach
+
+### Data Flow
+
+**Nested Mode (Default)**:
+```
+Input:  outputDir = /blog/_posts
+Flow:   imageDir = /blog/_posts/my-post
+        imagePathPrefix = .
+Output: /blog/_posts/my-post/index.md
+        /blog/_posts/my-post/image.png
+```
+
+**Flat Mode**:
+```
+Input:  outputDir = /blog/_posts, imageFolderName = _images
+        (Note: outputDir must be nested, not at root level)
+Flow:   imageDir = /blog/_images (sibling)
+        imagePathPrefix = /images
+Output: /blog/_posts/my-post.md
+        /blog/_images/image.png
+```
+
+**Requirements**:
+- outputDir must be a nested path (e.g., `/blog/_posts`, not `/posts`)
+- Ensures parent directory exists for creating sibling image folder
+- Validation error thrown if path is at filesystem root
+
+### Implementation Strategy
+
+1. **Mode routing at entry point**: `convertPost()` checks `this.outputStructure.mode` and routes to appropriate method
+2. **Dedicated conversion methods**: `convertPostNested()` and `convertPostFlat()` handle mode-specific path logic
+3. **Shared helper methods**: 6 helper methods eliminate ~70% code duplication between modes
+4. **Calculate paths conditionally** based on mode using `path.join()` and `path.dirname()`
+5. **Maintain type safety** with explicit type annotations (`ImageProcessingResult`, `PostMetadata`)
+6. **Enhance error handling** to classify flat-mode-specific errors (validation, directory creation)
+
+---
+
+## Actual Implementation
+
+The implementation uses a **mode-routing architecture** with separate conversion methods and shared helper functions.
+
+### Architecture
+
+**File**: [src/converter.ts](src/converter.ts)
+
+1. **Constructor Configuration** (lines 117-141):
+   ```typescript
+   constructor(deps?: ConverterDependencies) {
+     const config = { ...Converter.DEFAULT_CONFIG, ...deps?.config };
+     this.outputStructure = config.outputStructure; // Instance-level config
+
+     const outputMode = this.outputStructure.mode === 'flat' ? 'flat' : 'nested';
+     const defaultFileWriter = new FileWriter({ outputMode }); // Configured once
+     // ...
+   }
+   ```
+
+2. **Mode Routing** (lines 416-424):
+   ```typescript
+   async convertPost(...): Promise<ConvertedPost> {
+     const slug = this.extractSlugSafely(post, index);
+
+     // Route based on instance configuration
+     if (this.outputStructure.mode === 'flat') {
+       return this.convertPostFlat(post, slug, outputDir, options);
+     }
+     return this.convertPostNested(post, slug, outputDir, options);
+   }
+   ```
+
+3. **Shared Helper Methods** (lines 442-540):
+   - `parseAndTransform()`: Parse metadata and transform markdown
+   - `createImageProcessor()`: Handle ImageProcessor instantiation
+   - `ensureDirectoryExists()`: Unified directory creation
+   - `processImageResult()`: Event emission and error tracking
+   - `writeMarkdownFile()`: Frontmatter generation and file writing
+   - `createSuccessResult()`: Success result construction
+
+4. **Mode-Specific Methods**:
+   - `convertPostNested()` (lines 546-569): Nested structure with `imageProcessor.process()`
+   - `convertPostFlat()` (lines 607-641): Flat structure with `imageProcessor.processWithContext()`
+
+### Key Implementation Details
+
+**Nested Mode** (lines 546-569):
+```typescript
+private async convertPostNested(...): Promise<ConvertedPost> {
+  const { metadata, transformedMarkdown } = this.parseAndTransform(post);
+
+  const imageDir = path.join(outputDir, metadata.slug);  // {output}/{slug}/
+  this.ensureDirectoryExists(imageDir);
+
+  const imageProcessor = this.createImageProcessor(options);
+  const imageResult = await imageProcessor.process(transformedMarkdown, imageDir);
+
+  this.processImageResult(imageResult, metadata.slug);
+
+  const outputPath = await this.writeMarkdownFile(metadata, outputDir, imageResult);
+  return this.createSuccessResult(metadata, outputPath);
+}
+```
+
+**Flat Mode** (lines 607-641):
+```typescript
+private async convertPostFlat(...): Promise<ConvertedPost> {
+  this.validateFlatModeOutputPath(outputDir); // Path validation
+
+  const { metadata, transformedMarkdown } = this.parseAndTransform(post);
+
+  // Sibling directory structure
+  const parentDir = path.dirname(outputDir);
+  const imageFolderName = this.outputStructure.imageFolderName ?? '_images';
+  const imageDir = path.join(parentDir, imageFolderName);  // {parent}/_images/
+  const imagePathPrefix = this.outputStructure.imagePathPrefix ?? '/images';
+  this.ensureDirectoryExists(imageDir);
+
+  const imageProcessor = this.createImageProcessor(options);
+  const imageResult = await imageProcessor.processWithContext(transformedMarkdown, {
+    imageDir,
+    imagePathPrefix,
+  });
+
+  this.processImageResult(imageResult, metadata.slug);
+
+  const outputPath = await this.writeMarkdownFile(metadata, outputDir, imageResult);
+  return this.createSuccessResult(metadata, outputPath);
+}
+```typescript
+// Before
+} else if (errorMessage.includes('Failed to write') || errorMessage.includes('create directory')) {
+  errorType = 'write';
+}
+
+// After
+} else if (
+  errorMessage.includes('Failed to write') ||
+  errorMessage.includes('create directory') ||
+  errorMessage.includes('Image directory does not exist')
+) {
+  errorType = 'write';
+}
+```
+
+**Why**: `ImageProcessor.processWithContext()` throws "Image directory does not exist" for invalid paths. Should be classified as 'write' error.
+
+---
+
+## Testing Strategy
+
+### Unit Test Approach
+
+**File**: [tests/integration/converter.test.ts](tests/integration/converter.test.ts)
+
+**Test Categories**:
+
+#### A. Flat Mode Basic Usage (3 tests)
+- ✅ Should use `processWithContext` in flat mode
+- ✅ Should respect custom `imageFolderName`
+- ✅ Should respect custom `imagePathPrefix`
+
+#### B. FileWriter Integration (1 test)
+- ✅ Should create FileWriter with flat mode config (verify output path has no `/index.md`)
+
+#### C. Backward Compatibility (2 tests)
+- ✅ Should use nested mode by default (no options)
+- ✅ Should use nested mode when explicitly specified
+
+#### D. Error Handling (1 test)
+- ✅ Should handle image directory creation errors in flat mode
+
+**Total Tests**: ~7 new tests (targeting 99%+ coverage)
+
+### Test Coverage Targets
+
+| Metric | Target | Rationale |
+|--------|--------|-----------|
+| **Statements** | ≥99% | All code paths exercised |
+| **Branches** | ≥99% | All conditions tested (flat/nested) |
+| **Functions** | 100% | Method fully covered |
+| **Lines** | ≥99% | Complete line coverage |
+
+---
+
+## Integration Points
+
+### 1. Upstream (Input)
+- **Source**: `ConversionOptions` from CLI or programmatic API
+- **Input Type**: `OutputStructure` (optional)
+- **Integration**: Reads `options?.outputStructure` with default fallback
+
+### 2. Downstream (Output)
+- **Output Type**: `ConvertedPost` (unchanged)
+- **Next Stage**: FileWriter (creates files on disk)
+- **Integration**: FileWriter's `outputMode` config determines file naming
+
+### 3. Dependencies
+- **ImageProcessor**: Uses `processWithContext()` method (Phase 3.1)
+- **FileWriter**: Uses `outputMode` config (Phase 2)
+- **Types**: `OutputStructure` from `converter-options.ts` (Phase 1)
+
+---
+
+## Edge Cases & Solutions
+
+### 1. Parent Directory Doesn't Exist
+**Issue**: `outputDir = '/nonexistent/posts'` in flat mode
+**Solution**: `fs.mkdirSync(imageDir, { recursive: true })` creates all parent directories
+**Risk**: LOW - Standard Node.js behavior
+
+### 2. Image Directory Already Exists
+**Issue**: Second post in flat mode uses same `_images` directory
+**Solution**: `fs.existsSync()` check prevents redundant mkdir calls
+**Risk**: NONE - Idempotent operation
+
+### 3. Disk Space Exhausted
+**Issue**: `fs.mkdirSync()` fails with ENOSPC
+**Solution**: Caught by try/catch, returns `{ success: false, error: '...' }`
+**Risk**: LOW - Appropriate error handling exists
+
+### 4. Invalid imageFolderName
+**Issue**: `imageFolderName: '../escape'` (path traversal)
+**Mitigation**: Document that `imageFolderName` should be simple folder name
+**Risk**: LOW - Developer configuration, not user input
+
+### 5. Single-Level Output Directory
+**Issue**: `outputDir = '/output'` or `'./posts'` has no valid parent for sibling
+**Solution**: Validation throws clear error requiring nested path structure
+**Example Error**:
+```
+Invalid outputDir for flat mode: "/output"
+Flat mode requires a nested directory structure (e.g., "blog/_posts")
+Suggestions:
+  - Use: "./blog/_posts" or "/path/to/blog/_posts"
+  - Avoid: "/output" (single-level paths)
+```
+**Risk**: MEDIUM - Prevented by early validation
+
+---
+
+## Success Criteria
+
+### Functional Requirements
+- ✅ Flat mode routes to `processWithContext()` with correct context
+- ✅ Nested mode continues using `process()` unchanged
+- ✅ Image directory created at correct location per mode
+- ✅ FileWriter receives correct `outputMode` config
+
+### Non-Functional Requirements
+- ✅ **99%+** test coverage maintained (99.49% achieved)
+- ✅ No `any` types in implementation
+- ✅ TypeScript compilation passes
+- ✅ All existing tests pass (backward compatibility)
+- ✅ Build succeeds
+
+### Code Quality
+- ✅ Follows existing patterns (conditional routing, error handling)
+- ✅ Clear comments explaining mode selection logic
+- ✅ Comprehensive error handling for flat-mode scenarios
+
+---
+
+## Verification Checklist
+
+### Pre-Implementation
+- [x] GitHub Issue #51 reviewed
+- [x] Type definitions understood (`OutputStructure`, `ImageProcessorContext`)
+- [x] Phase 2 and Phase 3 implementations verified complete
+- [x] Current `convertPost` implementation analyzed
+
+### Post-Implementation
+
+```bash
+# Verify TypeScript compilation
+npm run type-check
+# Expected: No TypeScript errors
+
+# Verify build succeeds
+npm run build
+# Expected: dist/ directory created
+
+# Run all tests
+npm test
+# Expected: All 363+ tests pass
+
+# Generate coverage report
+npm run test:coverage
+# Expected: ≥99% coverage maintained
+```
+
+---
+
+## Critical Files
+
+- **[src/converter.ts](src/converter.ts)** - Primary implementation target (lines 375-455)
+- **[src/types/converter-options.ts](src/types/converter-options.ts)** - OutputStructure type definition
+- **[src/processors/image-processor.ts](src/processors/image-processor.ts)** - processWithContext() reference
+- **[src/services/file-writer.ts](src/services/file-writer.ts)** - outputMode config reference
+- **[tests/integration/converter.test.ts](tests/integration/converter.test.ts)** - Test suite to extend
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Breaking nested mode | LOW | HIGH | Comprehensive regression tests |
+| Performance regression | LOW | LOW | Lightweight FileWriter instances |
+| Type errors | LOW | LOW | TypeScript enforcement |
+| Invalid folder names | LOW | MEDIUM | Documentation + future validation |
+
+---
+
+## Next Steps After Implementation
+
+1. **Step 4.2**: Update `convertAllPosts` method
+   - Create FileWriter with correct mode for `postExists` check
+   - Create shared image directory once at start (optimization)
+
+2. **Step 4.3**: Write full integration tests
+   - Test complete pipeline with real filesystem
+   - Verify directory structures
+
+3. **Phase 5**: Add CLI flags (`--flat`, `--image-folder`, `--image-prefix`)
+
+---
+
+## Summary
+
+Phase 4, Step 4.1 updated `convertPost` to support flat output mode by:
+- Using instance-level `outputStructure` configuration (set at construction via `ConverterConfig`)
+- Routing to mode-specific conversion methods (`convertPostNested()` or `convertPostFlat()`)
+- Extracting 6 shared helper methods to eliminate ~70% code duplication
+- Calculating image paths based on mode (nested: `{output}/{slug}/`, flat: `{parent}/_images/`)
+- Using mode-specific ImageProcessor methods (`.process()` vs `.processWithContext()`)
+- Configuring FileWriter once at construction with the appropriate `outputMode`
+
+**Implementation Status**: ✅ Complete with 447 passing tests and 99.49% coverage

--- a/docs/features/flat/PHASE_4_STEP_4_2.md
+++ b/docs/features/flat/PHASE_4_STEP_4_2.md
@@ -1,0 +1,437 @@
+# Phase 4.2: Update Converter convertAllPosts Method for Flat Mode
+
+**Issue**: [#52 - Update Converter convertAllPosts Method for Flat Mode](https://github.com/alvincrespo/hashnode-content-converter/issues/52)
+**Status**: ✅ COMPLETE
+**Date**: 2026-02-05
+**Phase**: Phase 4 - Converter Updates, Step 4.2
+
+---
+
+## Overview
+
+Update the `convertAllPosts` method to properly handle flat mode by fixing a bug in the skip event path computation. After thorough code analysis, **most of the planned changes are already complete** from Phase 4.1. The only actual issue is line 335 hardcoding the nested path format.
+
+**Scope**: Fix skip event `outputPath` to use correct format based on output mode (nested vs flat)
+
+**Reference**: [docs/IMPLEMENTATION_FLAT.md](../../../IMPLEMENTATION_FLAT.md) (lines 872-902), [GitHub Issue #52](https://github.com/alvincrespo/hashnode-content-converter/issues/52)
+
+---
+
+## Key Findings from Code Analysis
+
+### Already Implemented ✅
+
+1. **FileWriter is mode-aware** ([src/converter.ts:132](../../../src/converter.ts#L132))
+   - Created at construction with correct `outputMode`
+   - `postExists()` method internally uses mode-aware path resolution
+   - No need to create new instance
+
+2. **Image directory handling** ([src/converter.ts:627-631](../../../src/converter.ts#L627-L631))
+   - Created per-post in `convertPostFlat()` method
+   - Works correctly, optimization is optional
+
+3. **Options passing** ([src/converter.ts:349](../../../src/converter.ts#L349))
+   - `outputStructure` passed through `effectiveOptions` to `convertPost()`
+
+### Bug Found 🐛
+
+**Line 335**: Skip event hardcodes nested path format
+```typescript
+outputPath: path.join(outputDir, slug, 'index.md'),  // ❌ Always nested
+```
+
+**Should be**:
+- Nested mode: `{outputDir}/{slug}/index.md`
+- Flat mode: `{outputDir}/{slug}.md`
+
+---
+
+## Requirements Summary
+
+From [docs/IMPLEMENTATION_FLAT.md](../../../IMPLEMENTATION_FLAT.md):
+
+**Original Planning Doc Requirements**:
+- ✅ Create FileWriter with correct output mode for `postExists` check (Already done - uses `this.fileWriter`)
+- ⚠️ Create shared image directory once at start (Optional enhancement - current per-post works fine)
+
+**Actual Requirements**:
+- ✅ Fix skip event `outputPath` to use correct format based on mode
+- ⚠️ Optional: Optimize image directory creation for flat mode
+
+---
+
+## Technical Approach
+
+### Solution: Use Post Model for Path Resolution
+
+The `Post` model ([src/models/post.ts:73-78](../../../src/models/post.ts#L73-L78)) has mode-aware path resolution:
+
+```typescript
+getFilePath(outputDir: string): string {
+  if (this.outputMode === 'flat') {
+    return path.join(outputDir, `${this.slug}.md`);
+  }
+  return path.join(outputDir, this.slug, 'index.md');
+}
+```
+
+**Strategy**: Create temporary `Post` instance to compute correct path for skip event.
+
+**Benefits**:
+- Reuses existing, tested path logic
+- Automatically handles both modes
+- Type-safe
+- No path duplication
+
+---
+
+## Implementation Steps
+
+### Step 1: Add Post Import
+
+**File**: [src/converter.ts:3](../../../src/converter.ts#L3)
+
+**Action**: Add import for Post model
+
+```typescript
+import { Post } from './models/post.js';
+```
+
+### Step 2: Create Helper Method
+
+**File**: [src/converter.ts](../../../src/converter.ts) (after line 857)
+
+**Action**: Add private helper method for skip path computation
+
+```typescript
+/**
+ * Get the output path for a skipped post based on output mode.
+ * Creates a temporary Post instance to compute the correct path.
+ *
+ * @param outputDir - Base output directory
+ * @param slug - Post slug
+ * @returns Full path to the markdown file
+ */
+private getSkipOutputPath(outputDir: string, slug: string): string {
+  try {
+    const outputMode = this.outputStructure.mode === 'flat' ? 'flat' : 'nested';
+    const tempPost = new Post({
+      slug,
+      frontmatter: '',
+      content: '',
+      outputMode,
+    });
+    return tempPost.getFilePath(outputDir);
+  } catch (error) {
+    // Fallback to nested format for invalid slugs
+    // This should rarely happen since postExists() validates first
+    return path.join(outputDir, slug, 'index.md');
+  }
+}
+```
+
+**Error Handling**: Catches `PostValidationError` for invalid slugs and falls back to nested format. This edge case is unlikely since `postExists()` would have failed first.
+
+### Step 3: Update Skip Event Creation
+
+**File**: [src/converter.ts:335](../../../src/converter.ts#L335)
+
+**Action**: Replace hardcoded path with helper method call
+
+**Before**:
+```typescript
+const skipResult: ConvertedPost = {
+  slug,
+  title: post.title || slug,
+  outputPath: path.join(outputDir, slug, 'index.md'),  // ❌ Hardcoded nested
+  success: true,
+};
+```
+
+**After**:
+```typescript
+const skipResult: ConvertedPost = {
+  slug,
+  title: post.title || slug,
+  outputPath: this.getSkipOutputPath(outputDir, slug),  // ✅ Mode-aware
+  success: true,
+};
+```
+
+---
+
+## Testing Strategy
+
+### Test 1: Skip Event Path - Nested Mode
+
+**File**: [tests/integration/converter.test.ts](../../../tests/integration/converter.test.ts)
+**Location**: "convertAllPosts - Skip Existing" describe block
+
+```typescript
+it('should emit skip event with correct nested path', async () => {
+  // Setup: Mock postExists to return true
+  vi.mocked(mockFileWriter.postExists).mockReturnValue(true);
+  const completedHandler = vi.fn();
+  converter.on('conversion-completed', completedHandler);
+
+  // Act
+  await converter.convertAllPosts(exportPath, outputDir, { skipExisting: true });
+
+  // Assert
+  expect(completedHandler).toHaveBeenCalledWith(
+    expect.objectContaining({
+      result: expect.objectContaining({
+        slug: 'test-post',
+        outputPath: path.join(outputDir, 'test-post', 'index.md'),
+        success: true,
+      }),
+    })
+  );
+});
+```
+
+### Test 2: Skip Event Path - Flat Mode
+
+**File**: [tests/integration/converter.test.ts](../../../tests/integration/converter.test.ts)
+**Location**: "Flat Output Mode" describe block
+
+```typescript
+it('should emit skip event with correct flat path when post exists', async () => {
+  // Setup: Create flat mode converter
+  const flatConverter = new Converter({
+    config: { outputStructure: { mode: 'flat' } },
+  });
+
+  vi.mocked(mockFileWriter.postExists).mockReturnValue(true);
+  const completedHandler = vi.fn();
+  flatConverter.on('conversion-completed', completedHandler);
+
+  // Act
+  await flatConverter.convertAllPosts(exportPath, outputDir, { skipExisting: true });
+
+  // Assert
+  expect(completedHandler).toHaveBeenCalledWith(
+    expect.objectContaining({
+      result: expect.objectContaining({
+        slug: 'test-post',
+        outputPath: path.join(outputDir, 'test-post.md'),
+        success: true,
+      }),
+    })
+  );
+});
+```
+
+### Test 3: Edge Case - Invalid Slug
+
+**File**: [tests/integration/converter.test.ts](../../../tests/integration/converter.test.ts)
+
+```typescript
+it('should handle invalid slugs in skip path gracefully', async () => {
+  // Setup: Post with invalid slug
+  const invalidPost = { ...samplePost, slug: '/absolute/path' };
+  const invalidExport = { posts: [invalidPost] };
+  vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(invalidExport));
+  vi.mocked(mockFileWriter.postExists).mockReturnValue(true);
+
+  const completedHandler = vi.fn();
+  converter.on('conversion-completed', completedHandler);
+
+  // Act
+  await converter.convertAllPosts(exportPath, outputDir, { skipExisting: true });
+
+  // Assert: Should fall back to nested format for invalid slugs
+  expect(completedHandler).toHaveBeenCalledWith(
+    expect.objectContaining({
+      result: expect.objectContaining({
+        outputPath: expect.stringMatching(/index\.md$/),
+      }),
+    })
+  );
+});
+```
+
+**Total New Tests**: 3 tests
+
+---
+
+## Optional Enhancement: Image Directory Optimization
+
+**Priority**: Low (current per-post creation works fine)
+
+**File**: [src/converter.ts](../../../src/converter.ts) (around line 303, after `ensureOutputDirectory()`)
+
+**Implementation**:
+```typescript
+// Create shared image directory once for flat mode (optimization)
+if (this.outputStructure.mode === 'flat') {
+  const parentDir = path.dirname(outputDir);
+  const imageFolderName = this.outputStructure.imageFolderName ?? '_images';
+  const imageDir = path.join(parentDir, imageFolderName);
+  this.ensureDirectoryExists(imageDir);
+  this.logger?.info(`Created shared image directory: ${imageDir}`);
+}
+```
+
+**Benefits**: Saves N filesystem checks (where N = number of posts)
+**Trade-off**: Adds mode-specific logic to `convertAllPosts`
+
+**Recommendation**: Skip for now - minimal performance gain, adds complexity
+
+---
+
+## Edge Cases and Considerations
+
+### 1. Invalid Slugs in Skip Path
+**Scenario**: Post has invalid slug (triggers `PostValidationError`)
+**Solution**: Try-catch in `getSkipOutputPath()` with fallback to nested format
+**Likelihood**: Very low (postExists would have failed first)
+
+### 2. Post Model Dependency
+**Scenario**: Adding dependency on Post model in Converter
+**Impact**: Post is part of internal models, safe to import
+**Verification**: Post model is already well-tested (99%+ coverage)
+
+### 3. Event Contract Change
+**Scenario**: Skip event `outputPath` changes for flat mode
+**Impact**: External consumers relying on specific path format
+**Mitigation**: This is a bug fix - nested mode always showed nested path, flat mode should show flat path (correct behavior)
+
+---
+
+## Success Criteria
+
+### Functional Requirements
+- ✅ Skip event emits correct path in nested mode (`{slug}/index.md`)
+- ✅ Skip event emits correct path in flat mode (`{slug}.md`)
+- ✅ Invalid slugs handled gracefully (fallback to nested format)
+
+### Non-Functional Requirements
+- ✅ All existing tests pass (444+ tests)
+- ✅ 3 new tests added (skip path validation)
+- ✅ Maintain 99%+ test coverage
+- ✅ TypeScript compilation passes
+- ✅ Build succeeds
+
+### Code Quality
+- ✅ Reuses existing Post model logic (no duplication)
+- ✅ Type-safe implementation
+- ✅ Comprehensive error handling
+- ✅ Clear JSDoc documentation
+
+---
+
+## Verification Checklist
+
+### Pre-Implementation
+- [x] Code exploration completed
+- [x] Bug identified and root cause understood
+- [x] Post model path resolution logic reviewed
+- [x] Test strategy designed
+
+### Post-Implementation
+
+```bash
+# Verify TypeScript compilation
+npm run type-check
+# Expected: No TypeScript errors
+
+# Verify build succeeds
+npm run build
+# Expected: dist/ directory created successfully
+
+# Run all tests
+npm test
+# Expected: All 447+ tests pass (including 3 new tests)
+
+# Generate coverage report
+npm run test:coverage
+# Expected: Maintain ≥99% coverage
+```
+
+---
+
+## Implementation Checklist
+
+### Phase 1: Core Fix
+- [x] Add Post import to converter.ts
+- [x] Create `getSkipOutputPath()` helper method
+- [x] Update line 335 to use helper method
+
+### Phase 2: Testing
+- [x] Add Test 1: Skip event path - nested mode
+- [x] Add Test 2: Skip event path - flat mode
+- [x] Add Test 3: Invalid slug edge case
+
+### Phase 3: Verification
+- [x] Run `npm run type-check` - verify no errors
+- [x] Run `npm run build` - verify success
+- [x] Run `npm test` - verify all tests pass
+- [x] Run `npm run test:coverage` - verify ≥99% coverage
+
+### Phase 4: Documentation
+- [x] Mark Step 4.2 complete in IMPLEMENTATION_FLAT.md
+- [x] Update GitHub issue #52 with completion status
+- [x] Create this plan document at docs/features/flat/PHASE_4_STEP_4_2.md
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Invalid slug breaks skip path | Very Low | Low | Try-catch with fallback |
+| Post model changes | Low | Medium | Post is internal, well-tested |
+| Breaking change to events | Low | Low | Bug fix - correct behavior |
+| Test failures | Very Low | Low | Comprehensive test coverage |
+
+---
+
+## Deviations from Planning Document
+
+**Original Plan** ([docs/IMPLEMENTATION_FLAT.md](../../../IMPLEMENTATION_FLAT.md) lines 872-902):
+
+1. ❌ "Create FileWriter with correct output mode for `postExists` check"
+   - **Not needed** - `this.fileWriter` already configured correctly at construction
+
+2. ❌ "Create shared image directory once at start"
+   - **Optional** - Current per-post creation works fine, optimization adds complexity
+
+3. ✅ "Update `convertAllPosts` method"
+   - **Simplified** - Only fix skip path bug, no major structural changes
+
+**Why different**: Phase 4.1 already implemented the core infrastructure. The planning doc was written before implementation and assumed more changes were needed.
+
+---
+
+## Timeline Estimate
+
+**Total Estimated Time**: 1-2 hours
+
+- **Phase 1** (Core Fix): 15 minutes
+- **Phase 2** (Testing): 30 minutes
+- **Phase 3** (Verification): 15 minutes
+- **Phase 4** (Documentation): 15 minutes
+
+---
+
+## Critical Files to Modify
+
+1. **[src/converter.ts](../../../src/converter.ts)** - Add Post import, create helper method, update line 335
+2. **[tests/integration/converter.test.ts](../../../tests/integration/converter.test.ts)** - Add 3 new test cases
+3. **[docs/IMPLEMENTATION_FLAT.md](../../../IMPLEMENTATION_FLAT.md)** - Mark Step 4.2 complete
+
+---
+
+## Summary
+
+**Phase 4.2** addresses a bug where skip events emit hardcoded nested paths regardless of output mode. The fix leverages the existing `Post.getFilePath()` method to compute mode-aware paths correctly.
+
+**Key Changes**:
+- Add `getSkipOutputPath()` helper method using Post model
+- Update skip event creation to use helper (line 335)
+- Add 3 tests validating both modes and edge cases
+
+**Impact**: Minimal changes, high confidence. The fix reuses proven path logic from the Post model, ensuring consistency and correctness.
+
+**Ready to implement?** This plan provides clear, step-by-step guidance for a focused bug fix with comprehensive test coverage.

--- a/docs/features/flat/PHASE_4_STEP_4_3.md
+++ b/docs/features/flat/PHASE_4_STEP_4_3.md
@@ -1,0 +1,861 @@
+# Phase 4.3: Converter Integration Tests for Flat Mode - Implementation Plan
+
+**Issue**: [#53 - Write Converter Integration Tests for Flat Mode](https://github.com/alvincrespo/hashnode-content-converter/issues/53)
+**Status**: ✅ COMPLETED
+**Date**: 2026-02-06
+**Phase**: Flat Output Mode Implementation - Step 4.3
+
+---
+
+## Overview
+
+Add 7 comprehensive integration tests for the flat output mode in `Converter.convertAllPosts()`. These tests will use **real file I/O** with temporary directories to verify the complete end-to-end pipeline, complementing the existing 10 unit tests that use mocks.
+
+**Scope**:
+- **In Scope**: Integration tests for `convertAllPosts()` with real filesystem operations, verifying actual file structure, markdown content, and skip behavior
+- **Out of Scope**: Additional `convertPost()` tests (already covered by 9 unit tests), real image downloads (will mock ImageDownloader)
+
+**Reference**: [docs/IMPLEMENTATION_FLAT.md](../docs/IMPLEMENTATION_FLAT.md#step-43-write-converter-integration-tests) (lines 904-977)
+
+---
+
+## Requirements Summary
+
+From [IMPLEMENTATION_FLAT.md](docs/IMPLEMENTATION_FLAT.md) (lines 904-977):
+
+### Functional Requirements
+1. ✅ Test full pipeline in flat mode produces `{slug}.md` files
+2. ✅ Test image directory created as sibling to output (`../_images/`)
+3. ✅ Test image path prefix (`/images/`) in output markdown content
+4. ✅ Test post existence check works with flat files (skip existing)
+5. ✅ Test custom `imageFolderName` option (e.g., `assets`)
+6. ✅ Test custom `imagePathPrefix` option (e.g., `/static/images`)
+7. ✅ Test nested mode unchanged (backward compatibility regression test)
+
+### Non-Functional Requirements
+- **99.5%+ test coverage** maintained (currently 450 tests passing)
+- **Real file I/O** using temporary directories
+- **Fast execution** by mocking image downloads (avoid network calls)
+- **No modifications** to existing 10 unit tests
+- **Follows existing patterns** from converter.test.ts
+
+---
+
+## Architecture Design
+
+### 1. Test Suite Structure
+
+**File**: `tests/integration/converter.test.ts`
+
+**New Test Block** (after existing flat mode tests):
+```typescript
+describe('convertAllPosts - Flat Output Mode Integration', () => {
+  let tempDir: string;
+  let exportPath: string;
+  let outputDir: string;
+  let converter: Converter;
+
+  beforeEach(() => {
+    // Create temp directory structure
+    // Setup real Converter instance (no mocks)
+    // Create export JSON with sample posts
+  });
+
+  afterEach(() => {
+    // Cleanup temp directories
+  });
+
+  // 7 integration tests here
+});
+```
+
+### 2. Test Architecture Pattern
+
+**Existing Tests** (lines 818-1062):
+- Type: Unit tests with mocked dependencies
+- Method: `convertPost()` (single post)
+- File I/O: Mocked (`vi.mock('node:fs')`)
+- Purpose: Verify internal wiring and option passing
+
+**New Tests** (Step 4.3):
+- Type: Integration tests with real file system
+- Method: `convertAllPosts()` (full pipeline)
+- File I/O: Real (temporary directories)
+- Purpose: Verify end-to-end functionality and actual output
+
+### 3. Key Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| **Use temp directories** | Isolated test environment, safe cleanup, no test pollution |
+| **Mock ImageDownloader only** | Keep tests fast, focus on file structure not network I/O |
+| **Focus on convertAllPosts** | Main gap in coverage; convertPost already has 9 unit tests |
+| **Separate test block** | Clear distinction from unit tests, no interference |
+| **Real Converter instance** | Test actual implementation, not mocked behavior |
+
+---
+
+## Technical Approach
+
+### 1. Test Environment Setup
+
+**Temporary Directory Pattern**:
+```typescript
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+
+beforeEach(() => {
+  // Create unique temp directory
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hashnode-flat-test-'));
+
+  // Setup directory structure for flat mode
+  outputDir = path.join(tempDir, 'blog', '_posts');
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  // Create export JSON
+  exportPath = path.join(tempDir, 'export.json');
+  const exportData = {
+    posts: [/* sample posts */]
+  };
+  fs.writeFileSync(exportPath, JSON.stringify(exportData));
+
+  // Create real Converter (mock ImageDownloader only)
+  converter = new Converter(/* real dependencies with mocked downloader */);
+});
+
+afterEach(() => {
+  // Cleanup
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+```
+
+### 2. Mocking Strategy
+
+**Mock Only ImageDownloader**:
+```typescript
+// Mock image downloads to avoid network calls
+vi.mock('../src/services/image-downloader.ts', () => ({
+  ImageDownloader: class MockImageDownloader {
+    async download(url: string, filepath: string) {
+      // Create empty file to simulate download
+      fs.writeFileSync(filepath, 'mock image data');
+      return { success: true, is403: false };
+    }
+
+    static extractHash(url: string): string {
+      // Extract hash from Hashnode CDN URL
+      const match = url.match(/\/([a-f0-9-]+)\.(png|jpg|jpeg|gif|webp)$/i);
+      return match ? `${match[1]}.${match[2]}` : 'default.png';
+    }
+  }
+}));
+```
+
+### 3. Verification Pattern
+
+**File Structure Assertion**:
+```typescript
+// Verify flat mode output structure
+expect(fs.existsSync(path.join(outputDir, 'post-slug.md'))).toBe(true);
+expect(fs.existsSync(path.join(outputDir, 'post-slug'))).toBe(false); // No directory
+
+// Verify image directory
+const imageDir = path.join(outputDir, '..', '_images');
+expect(fs.existsSync(imageDir)).toBe(true);
+```
+
+**Content Assertion**:
+```typescript
+// Read and verify markdown content
+const content = fs.readFileSync(path.join(outputDir, 'post-slug.md'), 'utf8');
+
+// Verify frontmatter
+expect(content).toMatch(/^---\n/);
+expect(content).toContain('title:');
+expect(content).toContain('slug: post-slug');
+
+// Verify image paths
+expect(content).toContain('![alt](/images/');
+expect(content).not.toContain('![alt](https://cdn.hashnode.com');
+```
+
+---
+
+## Implementation Steps
+
+### Test 1: Full Pipeline in Flat Mode
+
+**Purpose**: Verify `convertAllPosts()` creates `{slug}.md` files in flat mode
+
+**File**: `tests/integration/converter.test.ts` (new test block)
+
+**Implementation**:
+```typescript
+it('should write posts as {slug}.md in flat mode', async () => {
+  // Arrange
+  const exportData = {
+    posts: [
+      {
+        _id: 'test001',
+        slug: 'test-post-1',
+        title: 'Test Post 1',
+        contentMarkdown: '# Heading\n\nContent here.',
+        dateAdded: '2024-01-15T10:00:00.000Z',
+        brief: 'Test brief',
+        tags: [],
+      },
+      {
+        _id: 'test002',
+        slug: 'test-post-2',
+        title: 'Test Post 2',
+        contentMarkdown: '# Another Post',
+        dateAdded: '2024-01-16T10:00:00.000Z',
+        brief: 'Another brief',
+        tags: [],
+      },
+    ],
+  };
+  fs.writeFileSync(exportPath, JSON.stringify(exportData));
+
+  // Act
+  const result = await converter.convertAllPosts(exportPath, outputDir, {
+    outputStructure: { mode: 'flat' },
+    skipExisting: false,
+  });
+
+  // Assert - Result stats
+  expect(result.converted).toBe(2);
+  expect(result.skipped).toBe(0);
+  expect(result.errors).toHaveLength(0);
+
+  // Assert - File structure (flat mode)
+  expect(fs.existsSync(path.join(outputDir, 'test-post-1.md'))).toBe(true);
+  expect(fs.existsSync(path.join(outputDir, 'test-post-2.md'))).toBe(true);
+
+  // Assert - No nested directories created
+  expect(fs.existsSync(path.join(outputDir, 'test-post-1'))).toBe(false);
+  expect(fs.existsSync(path.join(outputDir, 'test-post-2'))).toBe(false);
+
+  // Assert - Content format
+  const content1 = fs.readFileSync(path.join(outputDir, 'test-post-1.md'), 'utf8');
+  expect(content1).toMatch(/^---\n/); // Frontmatter start
+  expect(content1).toContain('title: Test Post 1');
+  expect(content1).toContain('# Heading');
+});
+```
+
+---
+
+### Test 2: Image Directory as Sibling
+
+**Purpose**: Verify images are placed in sibling `_images` folder
+
+**Implementation**:
+```typescript
+it('should place images in sibling _images folder', async () => {
+  // Arrange
+  const exportData = {
+    posts: [{
+      _id: 'test001',
+      slug: 'post-with-image',
+      title: 'Post With Image',
+      contentMarkdown: '![alt](https://cdn.hashnode.com/res/hashnode/image/upload/abc-123.png)',
+      dateAdded: '2024-01-15T10:00:00.000Z',
+      brief: 'Test',
+      tags: [],
+    }],
+  };
+  fs.writeFileSync(exportPath, JSON.stringify(exportData));
+
+  // Act
+  await converter.convertAllPosts(exportPath, outputDir, {
+    outputStructure: { mode: 'flat' },
+  });
+
+  // Assert - Image directory structure
+  const imageDir = path.join(outputDir, '..', '_images');
+  expect(fs.existsSync(imageDir)).toBe(true);
+
+  // Assert - Image file exists (mocked download)
+  const imageFiles = fs.readdirSync(imageDir);
+  expect(imageFiles.length).toBeGreaterThan(0);
+  expect(imageFiles[0]).toMatch(/abc-123\.png/);
+
+  // Assert - Image not in post directory
+  const postDir = path.join(outputDir, 'post-with-image');
+  expect(fs.existsSync(postDir)).toBe(false);
+});
+```
+
+---
+
+### Test 3: Image Path Prefix in Markdown
+
+**Purpose**: Verify markdown contains `/images/` prefix for image references
+
+**Implementation**:
+```typescript
+it('should use /images prefix in markdown references', async () => {
+  // Arrange
+  const exportData = {
+    posts: [{
+      _id: 'test001',
+      slug: 'image-post',
+      title: 'Image Post',
+      contentMarkdown: 'Text ![alt](https://cdn.hashnode.com/res/hashnode/image/upload/xyz-789.jpg) more text',
+      dateAdded: '2024-01-15T10:00:00.000Z',
+      brief: 'Test',
+      tags: [],
+    }],
+  };
+  fs.writeFileSync(exportPath, JSON.stringify(exportData));
+
+  // Act
+  await converter.convertAllPosts(exportPath, outputDir, {
+    outputStructure: { mode: 'flat' },
+  });
+
+  // Assert - Read markdown content
+  const content = fs.readFileSync(path.join(outputDir, 'image-post.md'), 'utf8');
+
+  // Assert - Image path uses absolute prefix
+  expect(content).toContain('![alt](/images/xyz-789.jpg)');
+
+  // Assert - CDN URL replaced
+  expect(content).not.toContain('https://cdn.hashnode.com');
+
+  // Assert - Not using relative path
+  expect(content).not.toContain('![alt](./xyz-789.jpg)');
+});
+```
+
+---
+
+### Test 4: Skip Existing Files
+
+**Purpose**: Verify `skipExisting: true` works with flat files
+
+**Implementation**:
+```typescript
+it('should skip existing {slug}.md files when skipExisting is true', async () => {
+  // Arrange
+  const exportData = {
+    posts: [
+      {
+        _id: 'test001',
+        slug: 'existing-post',
+        title: 'Existing Post',
+        contentMarkdown: '# New Content',
+        dateAdded: '2024-01-15T10:00:00.000Z',
+        brief: 'Test',
+        tags: [],
+      },
+      {
+        _id: 'test002',
+        slug: 'new-post',
+        title: 'New Post',
+        contentMarkdown: '# Fresh Content',
+        dateAdded: '2024-01-16T10:00:00.000Z',
+        brief: 'Test',
+        tags: [],
+      },
+    ],
+  };
+  fs.writeFileSync(exportPath, JSON.stringify(exportData));
+
+  // Pre-create existing post file
+  const existingContent = '---\ntitle: Old Version\n---\n\n# Old Content';
+  fs.writeFileSync(path.join(outputDir, 'existing-post.md'), existingContent);
+
+  // Act
+  const result = await converter.convertAllPosts(exportPath, outputDir, {
+    outputStructure: { mode: 'flat' },
+    skipExisting: true,
+  });
+
+  // Assert - Stats
+  expect(result.converted).toBe(1); // Only new-post
+  expect(result.skipped).toBe(1); // existing-post
+
+  // Assert - Existing file unchanged
+  const existingFileContent = fs.readFileSync(
+    path.join(outputDir, 'existing-post.md'),
+    'utf8'
+  );
+  expect(existingFileContent).toBe(existingContent);
+  expect(existingFileContent).toContain('Old Version');
+  expect(existingFileContent).not.toContain('New Content');
+
+  // Assert - New file created
+  expect(fs.existsSync(path.join(outputDir, 'new-post.md'))).toBe(true);
+  const newFileContent = fs.readFileSync(path.join(outputDir, 'new-post.md'), 'utf8');
+  expect(newFileContent).toContain('Fresh Content');
+});
+```
+
+---
+
+### Test 5: Custom imageFolderName
+
+**Purpose**: Verify custom image folder name (e.g., `assets`)
+
+**Implementation**:
+```typescript
+it('should respect custom imageFolderName', async () => {
+  // Arrange
+  const exportData = {
+    posts: [{
+      _id: 'test001',
+      slug: 'custom-folder-post',
+      title: 'Custom Folder Post',
+      contentMarkdown: '![img](https://cdn.hashnode.com/res/hashnode/image/upload/custom-123.png)',
+      dateAdded: '2024-01-15T10:00:00.000Z',
+      brief: 'Test',
+      tags: [],
+    }],
+  };
+  fs.writeFileSync(exportPath, JSON.stringify(exportData));
+
+  // Act
+  await converter.convertAllPosts(exportPath, outputDir, {
+    outputStructure: {
+      mode: 'flat',
+      imageFolderName: 'assets', // Custom name
+    },
+  });
+
+  // Assert - Custom image directory exists
+  const customImageDir = path.join(outputDir, '..', 'assets');
+  expect(fs.existsSync(customImageDir)).toBe(true);
+
+  // Assert - Default _images directory NOT created
+  const defaultImageDir = path.join(outputDir, '..', '_images');
+  expect(fs.existsSync(defaultImageDir)).toBe(false);
+
+  // Assert - Image file in custom directory
+  const imageFiles = fs.readdirSync(customImageDir);
+  expect(imageFiles.some(f => f.includes('custom-123'))).toBe(true);
+});
+```
+
+---
+
+### Test 6: Custom imagePathPrefix
+
+**Purpose**: Verify custom image path prefix (e.g., `/static/images`)
+
+**Implementation**:
+```typescript
+it('should respect custom imagePathPrefix', async () => {
+  // Arrange
+  const exportData = {
+    posts: [{
+      _id: 'test001',
+      slug: 'custom-prefix-post',
+      title: 'Custom Prefix Post',
+      contentMarkdown: '![img](https://cdn.hashnode.com/res/hashnode/image/upload/prefix-456.jpg)',
+      dateAdded: '2024-01-15T10:00:00.000Z',
+      brief: 'Test',
+      tags: [],
+    }],
+  };
+  fs.writeFileSync(exportPath, JSON.stringify(exportData));
+
+  // Act
+  await converter.convertAllPosts(exportPath, outputDir, {
+    outputStructure: {
+      mode: 'flat',
+      imagePathPrefix: '/static/images', // Custom prefix
+    },
+  });
+
+  // Assert - Read markdown content
+  const content = fs.readFileSync(
+    path.join(outputDir, 'custom-prefix-post.md'),
+    'utf8'
+  );
+
+  // Assert - Custom prefix used
+  expect(content).toContain('![img](/static/images/prefix-456.jpg)');
+
+  // Assert - Default prefix NOT used
+  expect(content).not.toContain('![img](/images/prefix-456.jpg)');
+  expect(content).not.toContain('![img](./prefix-456.jpg)');
+});
+```
+
+---
+
+### Test 7: Backward Compatibility (Nested Mode)
+
+**Purpose**: Verify nested mode still works as default (regression test)
+
+**Implementation**:
+```typescript
+it('should maintain backwards compatibility in nested mode', async () => {
+  // Arrange
+  const exportData = {
+    posts: [{
+      _id: 'test001',
+      slug: 'nested-post',
+      title: 'Nested Post',
+      contentMarkdown: '![img](https://cdn.hashnode.com/res/hashnode/image/upload/nested-789.png)',
+      dateAdded: '2024-01-15T10:00:00.000Z',
+      brief: 'Test',
+      tags: [],
+    }],
+  };
+  fs.writeFileSync(exportPath, JSON.stringify(exportData));
+
+  // Act - No outputStructure option (defaults to nested)
+  await converter.convertAllPosts(exportPath, outputDir);
+
+  // Assert - Nested directory structure
+  const postDir = path.join(outputDir, 'nested-post');
+  expect(fs.existsSync(postDir)).toBe(true);
+  expect(fs.existsSync(path.join(postDir, 'index.md'))).toBe(true);
+
+  // Assert - No flat file
+  expect(fs.existsSync(path.join(outputDir, 'nested-post.md'))).toBe(false);
+
+  // Assert - Image in post directory
+  const imageFiles = fs.readdirSync(postDir);
+  expect(imageFiles.some(f => f.includes('nested-789'))).toBe(true);
+
+  // Assert - Content uses relative path
+  const content = fs.readFileSync(path.join(postDir, 'index.md'), 'utf8');
+  expect(content).toContain('![img](./nested-789.png)');
+  expect(content).not.toContain('/images/');
+});
+```
+
+---
+
+## Testing Strategy
+
+### 1. Setup Pattern
+
+```typescript
+describe('convertAllPosts - Flat Output Mode Integration', () => {
+  let tempDir: string;
+  let exportPath: string;
+  let outputDir: string;
+  let converter: Converter;
+  let mockDownloader: vi.MockedClass<typeof ImageDownloader>;
+
+  beforeEach(() => {
+    // 1. Create temp directory
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hashnode-flat-test-'));
+
+    // 2. Setup nested output structure (required for flat mode)
+    outputDir = path.join(tempDir, 'blog', '_posts');
+    fs.mkdirSync(outputDir, { recursive: true });
+
+    // 3. Mock ImageDownloader class
+    mockDownloader = vi.mocked(ImageDownloader);
+    mockDownloader.prototype.download = vi.fn().mockImplementation(
+      async (url: string, filepath: string) => {
+        fs.writeFileSync(filepath, 'mock image data');
+        return { success: true, is403: false };
+      }
+    );
+    mockDownloader.extractHash = vi.fn().mockImplementation((url: string) => {
+      const match = url.match(/\/([a-f0-9-]+)\.(png|jpg|jpeg|gif|webp)$/i);
+      return match ? `${match[1]}.${match[2]}` : 'default.png';
+    });
+
+    // 4. Create real Converter instance with real dependencies
+    converter = new Converter();
+
+    // 5. Export path (created per-test with specific data)
+    exportPath = path.join(tempDir, 'export.json');
+  });
+
+  afterEach(() => {
+    // Cleanup temp directory
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+
+    // Clear all mocks
+    vi.clearAllMocks();
+  });
+
+  // Tests here...
+});
+```
+
+### 2. Test Data Pattern
+
+**Sample Post Template**:
+```typescript
+const createSamplePost = (overrides: Partial<HashnodePost> = {}) => ({
+  _id: 'test001',
+  slug: 'test-post',
+  title: 'Test Post',
+  contentMarkdown: '# Test Content',
+  dateAdded: '2024-01-15T10:00:00.000Z',
+  brief: 'Test brief',
+  tags: [],
+  ...overrides,
+});
+```
+
+### 3. Assertion Helpers
+
+```typescript
+// Helper: Check file exists
+const expectFileExists = (relativePath: string) => {
+  const fullPath = path.join(outputDir, relativePath);
+  expect(fs.existsSync(fullPath)).toBe(true);
+};
+
+// Helper: Check file does not exist
+const expectFileNotExists = (relativePath: string) => {
+  const fullPath = path.join(outputDir, relativePath);
+  expect(fs.existsSync(fullPath)).toBe(false);
+};
+
+// Helper: Read file content
+const readFile = (relativePath: string): string => {
+  return fs.readFileSync(path.join(outputDir, relativePath), 'utf8');
+};
+```
+
+---
+
+## Integration Points
+
+### 1. Converter Entry Point
+
+**Method**: `Converter.convertAllPosts()`
+- **Input**: Export file path, output directory, options
+- **Options**: `{ outputStructure: { mode: 'flat', imageFolderName?, imagePathPrefix? } }`
+- **Output**: `ConversionResult` with stats
+
+### 2. File System
+
+**Real Operations**:
+- `fs.mkdtempSync()` - Create temp directories
+- `fs.mkdirSync()` - Create output directories
+- `fs.writeFileSync()` - Create export JSON and markdown files
+- `fs.readFileSync()` - Read generated markdown
+- `fs.readdirSync()` - List generated files
+- `fs.existsSync()` - Check file/directory existence
+- `fs.rmSync()` - Cleanup temp directories
+
+### 3. Mocked Dependencies
+
+**ImageDownloader** (only mocked component):
+- Mock `download()` to create empty files (avoid network)
+- Mock `extractHash()` to extract filename from CDN URLs
+- Real file creation simulates successful download
+
+---
+
+## Success Criteria
+
+### Functional Requirements
+- ✅ All 7 integration tests pass
+- ✅ Tests verify actual file structure on disk
+- ✅ Tests verify markdown content includes correct image paths
+- ✅ Tests verify skip existing logic with flat files
+- ✅ Tests verify custom options work correctly
+- ✅ Tests verify backward compatibility with nested mode
+
+### Non-Functional Requirements
+- ✅ 99.5%+ test coverage maintained
+- ✅ Tests execute in <5 seconds total
+- ✅ Tests are isolated (no shared state)
+- ✅ Tests cleanup temp directories
+- ✅ No modifications to existing tests
+
+### Code Quality
+- ✅ Tests follow existing patterns (beforeEach/afterEach)
+- ✅ Tests use descriptive assertion messages
+- ✅ Tests are readable and maintainable
+- ✅ Tests verify both positive and negative cases
+
+---
+
+## Verification Checklist
+
+### Pre-Implementation
+- [ ] Review existing tests (lines 818-1062)
+- [ ] Review Converter.convertAllPosts() implementation
+- [ ] Review temp directory patterns in Node.js
+- [ ] Confirm ImageDownloader mock approach
+
+### Post-Implementation
+
+```bash
+# Run only new integration tests
+npm test -- --run tests/integration/converter.test.ts -t "convertAllPosts - Flat Output Mode Integration"
+
+# Expected: 7 tests pass
+
+# Run all tests
+npm test -- --run
+
+# Expected: 457 tests pass (450 existing + 7 new)
+
+# Check coverage
+npm run test:coverage
+
+# Expected: 99.5%+ coverage maintained
+```
+
+---
+
+## Implementation Checklist
+
+### Phase 1: Setup (30 min)
+- [ ] Add new test block after existing flat mode tests
+- [ ] Implement beforeEach/afterEach with temp directory
+- [ ] Setup ImageDownloader mocks
+- [ ] Create sample post helper function
+
+### Phase 2: Core Tests (60 min)
+- [ ] Test 1: Full pipeline in flat mode
+- [ ] Test 2: Image directory as sibling
+- [ ] Test 3: Image path prefix in markdown
+- [ ] Test 4: Skip existing files
+
+### Phase 3: Configuration Tests (30 min)
+- [ ] Test 5: Custom imageFolderName
+- [ ] Test 6: Custom imagePathPrefix
+
+### Phase 4: Regression Test (15 min)
+- [ ] Test 7: Backward compatibility (nested mode)
+
+### Phase 5: Verification (30 min)
+- [ ] Run all tests and verify pass
+- [ ] Check coverage report (npm run test:coverage)
+- [ ] Review test output for clarity
+- [ ] Cleanup any console warnings
+
+### Phase 6: Documentation (15 min)
+- [ ] Update IMPLEMENTATION_FLAT.md checkboxes
+- [ ] Update GitHub issue #53 status
+- [ ] Document any deviations from plan
+
+---
+
+## Future Improvements
+
+### ImageProcessor Dependency Injection
+
+**Current Limitation**: `ImageProcessor` creates its own `ImageDownloader` internally, preventing proper mocking in integration tests:
+
+```typescript
+// Current implementation (src/processors/image-processor.ts:57-73)
+constructor(options?: ImageProcessorOptions) {
+  this.options = { /* ... */ };
+  this.downloader = new ImageDownloader({ /* ... */ }); // ← Created internally
+}
+```
+
+**Proposed Solution**: Add optional `downloader` parameter for dependency injection:
+
+```typescript
+constructor(
+  options?: ImageProcessorOptions,
+  downloader?: ImageDownloader
+) {
+  this.options = { /* ... */ };
+  this.downloader = downloader ?? new ImageDownloader({ /* ... */ });
+}
+```
+
+**Benefits**:
+- Enables reliable image download mocking in integration tests
+- Eliminates need for conditional assertions
+- Improves test predictability and eliminates false positives
+- Maintains backward compatibility (optional parameter)
+
+**Tracking**: [Issue #87 - Refactor ImageProcessor to support ImageDownloader dependency injection](https://github.com/alvincrespo/hashnode-content-converter/issues/87)
+
+---
+
+## Potential Challenges & Solutions
+
+### Challenge 1: Temp Directory Cleanup on Test Failure
+
+**Issue**: If a test fails mid-execution, temp directories might not be cleaned up
+
+**Solution**: Use `afterEach` with `force: true` option on `fs.rmSync()` to ensure cleanup even on failure
+
+**Risk Level**: Low
+
+---
+
+### Challenge 2: ImageDownloader Mock Complexity
+
+**Issue**: ImageDownloader has multiple methods and complex return types
+
+**Solution**: Mock only the essential methods (`download()`, `extractHash()`). Keep mock simple - just create empty files.
+
+**Risk Level**: Low
+
+---
+
+### Challenge 3: Test Execution Time
+
+**Issue**: 7 integration tests with real file I/O might slow down test suite
+
+**Solution**:
+- Mock ImageDownloader to avoid network delay
+- Use small test fixtures (1-2 posts per test)
+- Parallel test execution (Vitest default)
+
+**Risk Level**: Low (estimated <5s total for 7 tests)
+
+---
+
+## Timeline Estimate
+
+**Total Estimated Time**: 3-4 hours
+
+- **Phase 1** (Setup): 30 minutes
+- **Phase 2** (Core Tests): 60 minutes
+- **Phase 3** (Configuration Tests): 30 minutes
+- **Phase 4** (Regression Test): 15 minutes
+- **Phase 5** (Verification): 30 minutes
+- **Phase 6** (Documentation): 15 minutes
+
+---
+
+## Key Files
+
+| File | Action | Lines |
+|------|--------|-------|
+| `tests/integration/converter.test.ts` | **ADD** new test block | After line 1062 |
+| `docs/IMPLEMENTATION_FLAT.md` | **UPDATE** checkboxes | Lines 905-911 |
+
+---
+
+## Next Steps After Implementation
+
+1. Run full test suite: `npm test -- --run`
+2. Generate coverage report: `npm run test:coverage`
+3. Update GitHub issue #53 to "Complete"
+4. Mark Step 4.3 as complete in IMPLEMENTATION_FLAT.md
+5. Proceed to Step 4.4 (Document ImageProcessor Instance Independence)
+
+---
+
+## Summary
+
+**Step 4.3** will deliver **7 comprehensive integration tests** that:
+- Verify the complete `convertAllPosts()` pipeline with real file I/O
+- Test flat mode creates `{slug}.md` files and sibling image directories
+- Validate skip existing logic works with flat files
+- Confirm custom configuration options work correctly
+- Ensure backward compatibility with nested mode
+
+**Test Strategy**: Real filesystem operations with mocked image downloads for fast, reliable integration testing.
+
+**Coverage Impact**: Maintains 99.5%+ coverage while adding critical end-to-end validation.
+
+**Ready to implement?** This plan provides step-by-step guidance for building robust integration tests that complement the existing unit tests.

--- a/docs/features/flat/PHASE_4_STEP_4_4.md
+++ b/docs/features/flat/PHASE_4_STEP_4_4.md
@@ -1,0 +1,449 @@
+# Phase 4, Step 4.4: Document ImageProcessor Instance Independence - Implementation Plan
+
+**Issue**: [#63 - Document ImageProcessor Instance Independence](https://github.com/alvincrespo/hashnode-content-converter/issues/63)
+**Status**: ✅ IMPLEMENTED
+**Date**: 2026-02-06
+**Phase**: Phase 4 - Converter Updates, Step 4.4
+
+---
+
+## Overview
+
+Add documentation to the `ImageProcessor` class explaining that multiple instances can safely coexist because download state is persisted on disk via marker files, not in-memory. This addresses a non-obvious design decision that could appear problematic when reading the code.
+
+**Scope**: Documentation-only changes to `ImageProcessor` class JSDoc and constructor. No code behavior changes.
+
+**Reference**: [docs/IMPLEMENTATION_FLAT.md](../../../docs/IMPLEMENTATION_FLAT.md) (lines 980-1015), [GitHub Issue #63](https://github.com/alvincrespo/hashnode-content-converter/issues/63)
+
+---
+
+## Requirements Summary
+
+From [docs/IMPLEMENTATION_FLAT.md](../../../docs/IMPLEMENTATION_FLAT.md) (lines 980-1015) and GitHub Issue #63:
+
+### Functional Requirements
+1. ✅ Enhance `ImageProcessor` class-level JSDoc to explain instance independence
+2. ⏭️ Constructor JSDoc updates (skipped - Converter documentation already adequate)
+3. ✅ Reference the marker-based persistence mechanism
+4. ✅ Explain the design enables safe per-conversion custom options
+
+### Non-Functional Requirements
+- **Clear documentation** that answers "Won't creating new instances lose state?"
+- **Cross-references** between ImageProcessor and existing Converter documentation
+- **No code changes** - documentation only
+- **Follows existing JSDoc patterns** in the codebase
+
+---
+
+## Key Findings from Code Exploration
+
+### Already Documented ✅
+**Location**: [src/converter.ts:465-467](../../../src/converter.ts#L465-L467) (Converter.createImageProcessor method JSDoc)
+
+```typescript
+/**
+ * Note: Creating new instances is safe because download state is persisted
+ * via .downloaded-markers/ files on disk, not in-memory. Custom options
+ * only affect retry behavior for new/failed downloads.
+ */
+```
+
+**Insight**: The design rationale is ALREADY documented in Converter! Phase 4.4 should reference this and add similar documentation to ImageProcessor itself.
+
+### Missing Documentation 🔍
+**Location 1**: [src/processors/image-processor.ts:11-48](../../../src/processors/image-processor.ts#L11-L48) (class-level JSDoc)
+- Has detailed marker system documentation
+- **Missing**: Explanation of why multiple instances don't conflict
+
+**Location 2**: [src/processors/image-processor.ts:53-66](../../../src/processors/image-processor.ts#L53-L66) (constructor JSDoc)
+- Has TODO about dependency injection (Issue #87)
+- **Missing**: Clarification that current design is safe for Phase 4.4 use case
+
+---
+
+## Technical Approach
+
+### Documentation Strategy
+
+**Goal**: Make the instance independence design decision explicit and obvious to future developers.
+
+**Approach**:
+1. Add "Instance Independence" section to class-level JSDoc (after line 47)
+2. Add note to constructor JSDoc explaining safety (before existing TODO at line 58)
+3. Create comprehensive Phase 4.4 plan document
+4. Ensure consistency with existing Converter documentation
+
+### Documentation Locations
+
+| File | Lines | Section | Action |
+|------|-------|---------|--------|
+| [src/processors/image-processor.ts](../../../src/processors/image-processor.ts) | 11-48 | Class JSDoc | Add "Instance Independence" section after @example |
+| [src/processors/image-processor.ts](../../../src/processors/image-processor.ts) | 53-66 | Constructor JSDoc | Add safety note before TODO |
+| [docs/features/flat/PHASE_4_STEP_4_4.md](PHASE_4_STEP_4_4.md) | N/A | New file | Create plan document |
+
+---
+
+## Implementation Steps
+
+### Step 1: Enhance ImageProcessor Class-Level JSDoc
+
+**File**: [src/processors/image-processor.ts](../../../src/processors/image-processor.ts)
+**Line**: After line 47 (after @example block, before closing `*/`)
+
+**Action**: Add "Instance Independence" section
+
+**Proposed Addition**:
+```typescript
+/**
+ * ImageProcessor handles downloading images from Hashnode CDN...
+ *
+ * [... existing docs ...]
+ *
+ * @example
+ * [... existing example ...]
+ *
+ * Instance Independence:
+ * Multiple ImageProcessor instances safely coexist without state conflicts.
+ * Download state is persisted to disk via `.downloaded-markers/` files (not
+ * in-memory), so creating new instances with different options won't cause
+ * re-downloading of already-downloaded images.
+ *
+ * This design enables:
+ * - **Safe per-conversion custom options**: Different retry settings per post
+ * - **Resumable downloads**: Survives process restarts
+ * - **Parallel processing**: Multiple instances can run concurrently
+ * - **Flexible configuration**: Each conversion can use different download options
+ *
+ * @see {@link Converter.createImageProcessor} for usage in flat mode implementation
+ */
+```
+
+**Why this matters**: Developers reading the code might wonder "Won't this lose download state?" This section preemptively answers that concern.
+
+---
+
+### Step 2: Update ImageProcessor Constructor JSDoc
+
+**File**: [src/processors/image-processor.ts](../../../src/processors/image-processor.ts)
+**Line**: After line 57 (in constructor JSDoc, before TODO comment)
+
+**Current JSDoc** (lines 53-66):
+```typescript
+  /**
+   * Create a new ImageProcessor instance.
+   *
+   * @param options - Configuration options for image downloading
+   *
+   * TODO: Add optional `downloader` parameter for dependency injection...
+   */
+```
+
+**Action**: Add note about safety BEFORE the TODO
+
+**Proposed Addition**:
+```typescript
+  /**
+   * Create a new ImageProcessor instance.
+   *
+   * @param options - Configuration options for image downloading
+   *
+   * Note: Creating new instances is safe despite internal ImageDownloader creation.
+   * Download state persists via `.downloaded-markers/` files on disk, so each instance
+   * can check what has already been downloaded. This allows flexible per-conversion
+   * configuration without losing download history.
+   *
+   * TODO: Add optional `downloader` parameter for dependency injection to improve testability.
+   * [... existing TODO continues ...]
+   */
+```
+
+**Rationale**: The existing TODO might make developers think "This design is broken", so we clarify that while dependency injection would improve testability, the current design is functionally safe for production use.
+
+---
+
+### Step 3: Create Phase 4.4 Plan Document
+
+**File**: [docs/features/flat/PHASE_4_STEP_4_4.md](PHASE_4_STEP_4_4.md)
+
+**Action**: Create comprehensive plan document following the Phase_TEMPLATE.md pattern
+
+**Structure**:
+```markdown
+# Phase 4, Step 4.4: Document ImageProcessor Instance Independence
+
+**Issue**: [#63]
+**Status**: ✅ IMPLEMENTED / 📋 PLANNED
+**Date**: 2026-02-06
+**Phase**: Phase 4 - Converter Updates
+
+## Overview
+[2-4 sentences describing the documentation additions]
+
+## Requirements Summary
+[From IMPLEMENTATION_FLAT.md and Issue #63]
+
+## Architecture Design
+[Explanation of marker-based persistence system]
+
+## Implementation Steps
+[Step-by-step documentation changes]
+
+## Verification Checklist
+[How to verify documentation completeness]
+
+## Summary
+[Key takeaways]
+```
+
+**Content Focus**:
+- Why this documentation is necessary
+- The marker-based persistence mechanism
+- How multiple instances safely coexist
+- Cross-references to related code
+
+---
+
+## Testing Strategy
+
+### Verification Method: Documentation Review
+
+**No Code Tests Required** - This is documentation-only.
+
+**Manual Verification**:
+1. ✅ Read ImageProcessor class JSDoc - Does it explain instance independence?
+2. ✅ Read ImageProcessor constructor JSDoc - Does it explain why creating instances is safe?
+3. ✅ Check cross-references - Do docs link to Converter.createImageProcessor?
+4. ✅ Review for consistency - Do ImageProcessor and Converter docs tell the same story?
+5. ✅ Build TypeScript - `npm run build` should succeed (no doc syntax errors)
+
+**Documentation Quality Checklist**:
+- [x] Answers "Won't this lose state?" question
+- [x] Explains marker-based persistence clearly
+- [x] Lists benefits of design (resumable, parallel-safe, etc.)
+- [x] Consistent terminology with existing docs
+- [x] Proper JSDoc formatting (@see, @example, etc.)
+
+---
+
+## Integration Points
+
+### 1. Upstream Documentation
+- **Source**: [Converter.createImageProcessor()](../../../src/converter.ts#L461-L476) method JSDoc (lines 465-467)
+- **Content**: Already explains instance independence
+- **Integration**: ImageProcessor docs should reference this
+
+### 2. Downstream Usage
+- **Locations**: [Converter.convertPostNested():562](../../../src/converter.ts#L562), [Converter.convertPostFlat():635](../../../src/converter.ts#L635)
+- **Pattern**: Both call `this.createImageProcessor(options)` to get instance
+- **Integration**: Method JSDoc explains why this pattern is safe
+
+### 3. Related Issues
+- **Issue #87**: Dependency injection enhancement (referenced in TODO)
+- **Integration**: Clarify that #87 is for testability, not functional safety
+
+---
+
+## Success Criteria
+
+### Functional Requirements
+- ✅ ImageProcessor class JSDoc includes "Instance Independence" section
+- ✅ Constructor JSDoc explains why new instances are safe
+- ✅ Documentation references marker-based persistence mechanism
+- ✅ Cross-references link to Converter.createImageProcessor method
+
+### Non-Functional Requirements
+- ✅ Documentation is clear and concise
+- ✅ Follows existing JSDoc formatting conventions
+- ✅ No TypeScript build errors
+- ✅ Consistent with existing Converter documentation
+- ✅ Answers the "Won't this lose state?" question directly
+
+### Code Quality
+- ✅ Proper JSDoc syntax (@see, @example, etc.)
+- ✅ Professional technical writing
+- ✅ No unnecessary jargon
+- ✅ Helpful for future developers
+
+---
+
+## Verification Checklist
+
+### Pre-Implementation
+- [x] Review current ImageProcessor JSDoc (lines 11-48)
+- [x] Review current constructor JSDoc (lines 53-66)
+- [x] Review Converter.createImageProcessor JSDoc (lines 461-471)
+- [x] Understand marker-based persistence system
+- [x] Identify documentation gaps
+
+### Post-Implementation
+
+```bash
+# Verify TypeScript build succeeds
+npm run type-check
+# Expected: No errors (documentation syntax valid)
+
+# Verify build succeeds
+npm run build
+# Expected: dist/ created successfully
+
+# Visual inspection of generated docs
+cat src/processors/image-processor.ts | grep -A 20 "Instance Independence"
+# Expected: New documentation section visible
+```
+
+---
+
+## Implementation Checklist
+
+### Phase 1: ImageProcessor Class Documentation
+- [x] Add "Instance Independence" section to class-level JSDoc (after line 47)
+- [x] Include benefits list (resumable, parallel-safe, etc.)
+- [x] Add @see reference to Converter.createImageProcessor
+
+### Phase 2: Constructor Documentation
+- [x] Skip - Converter documentation already adequate
+- [x] No additional constructor JSDoc changes needed
+- [x] Clarify TODO is for testability, not safety
+
+### Phase 3: Plan Document
+- [x] Create docs/features/flat/PHASE_4_STEP_4_4.md
+- [x] Follow Phase_TEMPLATE.md structure
+- [x] Document marker-based persistence mechanism
+- [x] Include verification checklist
+
+### Phase 4: Verification
+- [x] Run npm run type-check
+- [x] Run npm run build
+- [x] Visual inspection of JSDoc
+- [x] Check cross-references work
+
+### Phase 5: Update Tracking
+- [x] Mark Step 4.4 complete in IMPLEMENTATION_FLAT.md
+- [x] Pull Request #88 created (will close Issue #63 on merge)
+- [x] Update plan document status to "✅ IMPLEMENTED"
+
+---
+
+## Key Files
+
+| File | Action | Lines |
+|------|--------|-------|
+| [src/processors/image-processor.ts](../../../src/processors/image-processor.ts) | **EDIT** class JSDoc | After line 47 |
+| [src/processors/image-processor.ts](../../../src/processors/image-processor.ts) | **EDIT** constructor JSDoc | After line 57 |
+| [docs/features/flat/PHASE_4_STEP_4_4.md](PHASE_4_STEP_4_4.md) | **CREATE** plan document | New file |
+| [docs/IMPLEMENTATION_FLAT.md](../../../docs/IMPLEMENTATION_FLAT.md) | **UPDATE** checkbox | Line 981 |
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| TypeScript syntax error in JSDoc | LOW | LOW | Verify with `npm run type-check` |
+| Documentation unclear | LOW | MEDIUM | Follow existing JSDoc patterns, get review |
+| Inconsistent with Converter docs | VERY LOW | LOW | Reference existing docs (lines 465-467) |
+| Breaking existing JSDoc consumers | NONE | N/A | Additive only, no removals |
+
+---
+
+## Potential Challenges & Solutions
+
+### Challenge 1: JSDoc Formatting
+
+**Issue**: JSDoc has specific syntax for cross-references (@see, @link)
+
+**Solution**: Follow existing patterns in the codebase. Use `@see` for method references:
+```typescript
+@see {@link Converter.createImageProcessor} for usage in flat mode
+```
+
+**Risk Level**: LOW
+
+---
+
+### Challenge 2: Explaining Marker System Concisely
+
+**Issue**: Marker-based persistence is complex, need to explain briefly without overwhelming
+
+**Solution**: Use bullet points and focus on the outcome ("instances don't conflict") rather than implementation details. Link to existing marker documentation in class JSDoc.
+
+**Risk Level**: LOW
+
+---
+
+### Challenge 3: Balancing TODO with Safety Note
+
+**Issue**: Existing TODO about dependency injection might conflict with "current design is safe"
+
+**Solution**: Explicitly state: "While dependency injection would improve testability (see TODO), the current design is functionally safe for production use because..."
+
+**Risk Level**: VERY LOW
+
+---
+
+## Timeline Estimate
+
+**Total Estimated Time**: 1-2 hours
+
+- **Phase 1** (Class JSDoc): 30 minutes
+- **Phase 2** (Constructor JSDoc): 15 minutes
+- **Phase 3** (Plan Document): 30 minutes
+- **Phase 4** (Verification): 15 minutes
+- **Phase 5** (Update Tracking): 15 minutes
+
+---
+
+## Reference Implementation
+
+### Current Converter Documentation (Model to Follow)
+
+**File**: [src/converter.ts:465-467](../../../src/converter.ts#L465-L467)
+
+```typescript
+/**
+ * Create an ImageProcessor instance based on conversion options.
+ * When custom downloadOptions are provided, creates a new instance.
+ * Otherwise, uses the instance's default ImageProcessor.
+ *
+ * Note: Creating new instances is safe because download state is persisted
+ * via .downloaded-markers/ files on disk, not in-memory. Custom options
+ * only affect retry behavior for new/failed downloads.
+ *
+ * @param options - Conversion options that may include downloadOptions
+ * @returns ImageProcessor instance (new or default)
+ */
+```
+
+**Key Elements to Replicate**:
+1. Direct statement: "Creating new instances is safe because..."
+2. Mechanism: "download state is persisted via .downloaded-markers/ files"
+3. Location: "on disk, not in-memory"
+4. Implication: "Custom options only affect retry behavior"
+
+---
+
+## Next Steps After Implementation
+
+1. Run `npm run type-check` to verify JSDoc syntax
+2. Run `npm run build` to verify no build errors
+3. Visual inspection of generated documentation
+4. Mark Step 4.4 as complete in IMPLEMENTATION_FLAT.md
+5. Close GitHub Issue #63
+6. Proceed to Phase 5: CLI Updates
+
+---
+
+## Summary
+
+**Phase 4, Step 4.4** will add comprehensive documentation explaining that `ImageProcessor` instances are independent and safe to create multiple times. The key insight is that download state is persisted on disk via marker files, not in-memory, so creating new instances with custom options doesn't cause duplicate downloads or state loss.
+
+**Documentation Additions**:
+1. Class-level JSDoc section explaining instance independence and benefits
+2. Cross-reference link to Converter.createImageProcessor for discoverability
+3. Comprehensive Phase 4.4 plan document
+
+**Impact**: Minimal code changes (documentation only), high clarity gain for future developers.
+
+**Risk**: Very low - additive documentation with TypeScript validation.
+
+**Ready to implement?** This plan provides clear, step-by-step guidance for adding documentation that makes the design decision explicit and obvious.

--- a/docs/features/flat/PHASE_5_STEP_5_1.md
+++ b/docs/features/flat/PHASE_5_STEP_5_1.md
@@ -1,0 +1,420 @@
+# Phase 5.1: Update CLIOptions Interface for Flat Mode - Implementation Plan
+
+**Issue**: [#54 - 5.1 Update CLIOptions Interface for Flat Mode](https://github.com/alvincrespo/hashnode-content-converter/issues/54)
+**Status**: ✅ COMPLETE
+**Date**: 2026-02-06
+**Phase**: Phase 5 - CLI Updates, Step 5.1
+**PR**: [#90](https://github.com/alvincrespo/hashnode-content-converter/pull/90)
+
+---
+
+## Overview
+
+Update the `CLIOptions` interface in `src/cli/convert.ts` to include three new fields that support flat output mode configuration. This is the first step in a series of CLI updates that will enable users to activate flat mode via command-line flags.
+
+**Scope**:
+- ✅ In scope: Adding three new fields to the `CLIOptions` TypeScript interface
+- ❌ Out of scope: Commander.js flag definitions, validation logic, or option transformation (covered in subsequent steps)
+
+**Reference**: [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) (lines 1020-1040)
+
+---
+
+## Requirements Summary
+
+From [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) Phase 5, Step 5.1:
+
+**Required Interface Changes**:
+- Add `flat: boolean` - Enable flat output mode
+- Add `imageFolder?: string` - Optional image folder name (flat mode only)
+- Add `imagePrefix?: string` - Optional image path prefix (flat mode only)
+
+**Key Requirements**:
+- Match existing code style and JSDoc documentation patterns
+- Use consistent naming conventions with existing CLI options
+- Maintain TypeScript strict mode compliance
+- Follow interface field ordering conventions
+
+---
+
+## Architecture Design
+
+### 1. Interface API Design
+
+#### Current CLIOptions Interface (lines 23-36)
+
+```typescript
+interface CLIOptions {
+  export: string;
+  output: string;
+  logFile?: string;
+  skipExisting: boolean;
+  verbose: boolean;
+  quiet: boolean;
+}
+```
+
+#### Proposed CLIOptions Interface
+
+```typescript
+interface CLIOptions {
+  export: string;
+  output: string;
+  logFile?: string;
+  skipExisting: boolean;
+  verbose: boolean;
+  quiet: boolean;
+  flat: boolean;           // NEW
+  imageFolder?: string;    // NEW
+  imagePrefix?: string;    // NEW
+}
+```
+
+### 2. Design Patterns
+
+**Following Existing Conventions**:
+1. **Field Ordering**: Boolean flags before optional strings (observed pattern)
+2. **JSDoc Style**: Single-line comments explaining purpose, not implementation
+3. **Naming**: Camel case, descriptive names matching CLI flag intent
+4. **Optional Fields**: Use `?` suffix for optional configuration
+
+**Key Decisions**:
+1. **`flat` as boolean**: Required boolean (not optional) because it must default to `false` for backwards compatibility
+2. **`imageFolder` and `imagePrefix` as optional**: These have sensible defaults and only apply in flat mode
+3. **Field names match CLI flags**: `--flat` → `flat`, `--image-folder` → `imageFolder`, `--image-prefix` → `imagePrefix`
+
+---
+
+## Technical Approach
+
+### 1. Interface Extension Strategy
+
+This is a straightforward additive change:
+- Add three new fields to the existing interface
+- No breaking changes to existing fields
+- No changes to the interface location or export
+
+### 2. JSDoc Documentation Pattern
+
+Based on existing patterns in the codebase, each field should have:
+- Clear description of purpose
+- Default value indication where applicable
+- Scope indication (e.g., "flat mode only")
+
+Example from existing code:
+```typescript
+/** Skip posts that already exist (default: true via --no-skip-existing) */
+skipExisting: boolean;
+```
+
+---
+
+## Implementation Steps
+
+### Step 1: Add JSDoc Comments for New Fields
+
+**File**: [src/cli/convert.ts](../../../src/cli/convert.ts)
+**Location**: Lines 23-36 (CLIOptions interface)
+
+**Action**: Add JSDoc comments following existing patterns
+
+**Implementation**:
+
+```typescript
+interface CLIOptions {
+  /** Path to Hashnode export JSON file */
+  export: string;
+  /** Output directory for converted posts */
+  output: string;
+  /** Optional path to log file */
+  logFile?: string;
+  /** Skip posts that already exist (default: true via --no-skip-existing) */
+  skipExisting: boolean;
+  /** Enable verbose output */
+  verbose: boolean;
+  /** Suppress progress output (only show summary) */
+  quiet: boolean;
+  /** Enable flat output mode ({slug}.md instead of {slug}/index.md) */
+  flat: boolean;
+  /** Image folder name in flat mode (default: _images) */
+  imageFolder?: string;
+  /** Image path prefix in flat mode (default: /images) */
+  imagePrefix?: string;
+}
+```
+
+**Rationale**:
+- `flat` explains what changes in the output structure
+- `imageFolder` clarifies it's flat mode only and includes default
+- `imagePrefix` clarifies it's flat mode only and includes default
+
+---
+
+## Testing Strategy
+
+### 1. Type Checking Verification
+
+Since this is a TypeScript interface change, verification is primarily through type checking:
+
+**Verification Commands**:
+```bash
+# Verify TypeScript compilation
+npm run type-check
+# Expected: No TypeScript errors
+
+# Verify build succeeds
+npm run build
+# Expected: dist/ directory created successfully
+```
+
+### 2. No Unit Tests Required
+
+**Rationale**: TypeScript interfaces are compile-time only and don't exist at runtime. Testing will occur in subsequent steps when:
+- CLI flags are defined (Step 5.2)
+- Options are parsed and transformed (Step 5.3)
+- Integration tests validate end-to-end behavior (Step 5.5)
+
+---
+
+## Integration Points
+
+### 1. Downstream Usage (Subsequent Steps)
+
+**Step 5.2** - Add CLI Flags:
+- Will reference `CLIOptions.flat` when defining commander.js flag
+- Will reference `CLIOptions.imageFolder` for `--image-folder` option
+- Will reference `CLIOptions.imagePrefix` for `--image-prefix` option
+
+**Step 5.3** - Build outputStructure:
+- Will read `options.flat` to determine if flat mode is enabled
+- Will read `options.imageFolder` and `options.imagePrefix` for configuration
+- Will construct `OutputStructure` object from these fields
+
+### 2. Type Safety Guarantees
+
+Adding these fields provides:
+- Compile-time checks that all CLI option usage is type-safe
+- Auto-completion in IDEs when working with `CLIOptions`
+- Prevention of typos in property access (e.g., `options.imageFolder` vs `options.imagefolder`)
+
+---
+
+## Potential Challenges & Solutions
+
+### Challenge 1: Field Naming Consistency
+
+**Issue**: CLI flags use kebab-case (`--image-folder`) but TypeScript uses camelCase (`imageFolder`)
+
+**Solution**: This is standard commander.js behavior - it automatically converts kebab-case flags to camelCase properties. Verified in existing code:
+- `--skip-existing` → `skipExisting`
+- `--log-file` → `logFile`
+
+**Risk Level**: Low (established pattern)
+
+### Challenge 2: Optional vs Required Fields
+
+**Issue**: Determining which new fields should be optional
+
+**Solution**:
+- `flat` is required (must have a value, defaults to `false`)
+- `imageFolder` and `imagePrefix` are optional (only used in flat mode, have defaults)
+
+**Risk Level**: Low (matches existing patterns like `logFile?`)
+
+---
+
+## Success Criteria
+
+### Functional Requirements
+- ☐ `flat: boolean` field added to CLIOptions
+- ☐ `imageFolder?: string` field added to CLIOptions
+- ☐ `imagePrefix?: string` field added to CLIOptions
+
+### Non-Functional Requirements
+- ☐ TypeScript compilation passes (`npm run type-check`)
+- ☐ Build succeeds (`npm run build`)
+- ☐ JSDoc comments follow existing patterns
+- ☐ Field ordering is logical and consistent
+- ☐ No breaking changes to existing fields
+
+### Code Quality
+- ☐ Follows existing code style (spacing, indentation)
+- ☐ JSDoc comments are clear and helpful
+- ☐ Optional fields use `?` suffix appropriately
+
+---
+
+## Verification Checklist
+
+### Pre-Implementation
+- [x] GitHub Issue #54 reviewed
+- [x] Source document (IMPLEMENTATION_FLAT.md) analyzed
+- [x] Existing CLIOptions interface understood
+- [x] CLI patterns and conventions studied
+
+### Post-Implementation
+
+```bash
+# Verify TypeScript compilation
+npm run type-check
+# Expected: No TypeScript errors, clean compilation
+
+# Verify build succeeds
+npm run build
+# Expected: dist/ directory created with compiled files
+
+# Optional: Run existing tests to ensure no regressions
+npm test
+# Expected: All existing tests pass (no test changes needed for this step)
+```
+
+**Manual Verification**:
+1. Open [src/cli/convert.ts](../../../src/cli/convert.ts) in IDE
+2. Confirm auto-completion shows new fields when typing `options.`
+3. Confirm JSDoc tooltips display correctly for new fields
+
+---
+
+## Git Workflow
+
+This implementation follows a branch-per-step workflow for clean, reviewable commits.
+
+### Branch Strategy
+
+**Source Branch**: `feature/flat-output-mode` (base branch for flat mode work)
+**Implementation Branch**: `flat-output-mode/phase-5-step-5-1`
+
+**Branch Naming Convention**: `flat-output-mode/phase-{phase}-step-{step}`
+
+### Commit Strategy
+
+Create atomic commits for each logical step:
+1. **After interface changes**: Commit the CLIOptions interface update
+2. **After verification passes**: Commit any adjustments if needed
+3. **After documentation updates**: Commit plan status updates
+
+**Commit Message Format**:
+```
+feat: Phase 5.1 - Add flat mode fields to CLIOptions interface
+
+- Add flat: boolean field for enabling flat output mode
+- Add imageFolder?: string for custom image folder name
+- Add imagePrefix?: string for custom image path prefix
+
+Refs #54
+```
+
+### Pull Request
+
+After implementation and verification:
+- Push branch to GitHub
+- Create PR targeting `feature/flat-output-mode`
+- Link to issue #54
+- Include testing evidence (type-check and build output)
+
+---
+
+## Implementation Checklist
+
+### Phase 0: Git Setup
+- [x] Checkout `feature/flat-output-mode` branch
+- [x] Pull latest changes: `git pull origin feature/flat-output-mode`
+- [x] Create new branch: `git checkout -b flat-output-mode/phase-5-step-5-1`
+
+### Phase 1: Core Implementation
+- [x] Open [src/cli/convert.ts](../../../src/cli/convert.ts)
+- [x] Locate `CLIOptions` interface (lines 23-36)
+- [x] Add `flat: boolean` field with JSDoc comment
+- [x] Add `imageFolder?: string` field with JSDoc comment
+- [x] Add `imagePrefix?: string` field with JSDoc comment
+
+### Phase 2: Verification
+- [x] Run `npm run type-check` to verify compilation
+- [x] Run `npm run build` to verify build succeeds
+- [x] Verify in IDE that auto-completion works for new fields
+
+### Phase 3: Commit Changes
+- [x] Stage changes: `git add src/cli/convert.ts`
+- [x] Create commit with descriptive message (see Git Workflow section)
+- [x] Verify commit: `git log -1 --stat`
+
+### Phase 4: Push and Create PR
+- [x] Push branch: `git push -u origin flat-output-mode/phase-5-step-5-1`
+- [x] Create pull request on GitHub targeting `feature/flat-output-mode`
+- [x] Link PR to issue #54
+- [x] Add PR description with verification evidence
+
+### Phase 5: Documentation
+- [x] Update this plan's status to COMPLETE
+- [x] Update GitHub issue #54 with PR link
+- [x] Proceed to Step 5.2 (Add CLI Flags)
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Typo in field names | Low | Medium | TypeScript compiler catches unused fields in subsequent steps |
+| Incorrect optional marking | Low | Medium | Clear defaults in source doc; verified against patterns |
+| Breaking existing code | Very Low | High | No changes to existing fields; additive only |
+| JSDoc format inconsistency | Low | Low | Follow existing patterns; review in IDE |
+
+---
+
+## Timeline Estimate
+
+**Total Estimated Time**: 10-15 minutes
+
+- **Phase 0** (Git Setup): 1-2 minutes
+  - Checkout and create branch
+
+- **Phase 1** (Core Implementation): 5-10 minutes
+  - Locate interface
+  - Add three fields with JSDoc
+  - Format consistently
+
+- **Phase 2** (Verification): 3-5 minutes
+  - Run type-check
+  - Run build
+  - Verify in IDE
+
+- **Phase 3** (Commit): 2 minutes
+  - Stage and commit changes
+
+- **Phase 4** (PR): 2-3 minutes
+  - Push and create PR
+
+---
+
+## Related Files
+
+**Files to Modify**:
+- [src/cli/convert.ts](../../../src/cli/convert.ts) - Add fields to CLIOptions interface (lines 23-36)
+
+**Files to Reference** (no changes):
+- [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) - Source requirements
+- [src/types/converter-options.ts](../../../src/types/converter-options.ts) - OutputStructure type (created in Phase 1)
+
+---
+
+## Next Steps After Implementation
+
+After completing Step 5.1, proceed to:
+
+1. **Step 5.2**: Add CLI Flags - Define commander.js options for `--flat`, `--image-folder`, `--image-prefix`
+2. **Step 5.3**: Build outputStructure from CLI Options - Transform CLI options to `ConversionOptions`
+3. **Step 5.4**: Update Startup Display - Show mode information to user
+4. **Step 5.5**: Write CLI Unit Tests - Validate flag parsing and transformation
+
+---
+
+## Summary
+
+**Phase 5.1** will deliver an updated `CLIOptions` interface that:
+- Includes a `flat` boolean field to enable flat output mode
+- Includes optional `imageFolder` and `imagePrefix` fields for customization
+- Maintains backwards compatibility (additive change only)
+- Follows existing code patterns and documentation style
+
+**Ready to implement?** This is a straightforward interface update with clear requirements and no architectural complexity. The changes are minimal, well-defined, and set the foundation for the subsequent CLI implementation steps.

--- a/docs/features/flat/PHASE_5_STEP_5_2.md
+++ b/docs/features/flat/PHASE_5_STEP_5_2.md
@@ -1,0 +1,415 @@
+# Phase 5.2: Add CLI Flags for Flat Mode - Implementation Plan
+
+**Issue**: [#55 - 5.2 Add CLI Flags for Flat Mode](https://github.com/alvincrespo/hashnode-content-converter/issues/55)
+**Status**: ✅ COMPLETE
+**Date**: 2026-02-10
+**Phase**: Phase 5 - CLI Updates, Step 5.2
+
+---
+
+## Overview
+
+Add three new commander.js `.option()` definitions to the CLI `convert` command: `--flat`, `--image-folder`, and `--image-prefix`. This step makes the flags parseable by commander.js, bridging the gap between the `CLIOptions` interface (added in Step 5.1) and actual command-line usage.
+
+**Scope**:
+- In scope: Adding three `.option()` calls to the commander.js command builder
+- Out of scope: Validation logic, `outputStructure` construction, startup display changes, Converter wiring (Steps 5.3-5.5)
+
+**Reference**: [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) (lines 1042-1066)
+
+---
+
+## Requirements Summary
+
+From [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) Phase 5, Step 5.2:
+
+- Add `-f, --flat` boolean flag (default: `false`)
+- Add `--image-folder <name>` string option (flat mode only)
+- Add `--image-prefix <prefix>` string option (flat mode only)
+- Update help text with descriptive option text
+
+**Key Requirements**:
+- Commander.js auto-converts kebab-case flags to camelCase (matching `CLIOptions` interface)
+- `--flat` must default to `false` for backwards compatibility
+- `--image-folder` and `--image-prefix` have no CLI-level defaults (downstream defaults in Step 5.3)
+- Short flag `-f` for `--flat` (consistent with single-letter shortcut convention)
+
+---
+
+## Architecture Design
+
+### 1. CLI Option Registration
+
+#### Current Program Setup (lines 336-347)
+
+```typescript
+program
+  .command('convert')
+  .description('Convert a Hashnode export JSON file to Markdown files')
+  .requiredOption('-e, --export <path>', 'Path to Hashnode export JSON file')
+  .requiredOption('-o, --output <path>', 'Output directory for converted posts')
+  .option('-l, --log-file <path>', 'Path to log file (optional)')
+  .option('--no-skip-existing', 'Overwrite posts that already exist')
+  .option('-v, --verbose', 'Enable verbose output', false)
+  .option('-q, --quiet', 'Suppress progress output (only show summary)', false)
+  .action(async (options: CLIOptions) => {
+    await runConvert(options);
+  });
+```
+
+#### Proposed Program Setup
+
+```typescript
+program
+  .command('convert')
+  .description('Convert a Hashnode export JSON file to Markdown files')
+  .requiredOption('-e, --export <path>', 'Path to Hashnode export JSON file')
+  .requiredOption('-o, --output <path>', 'Output directory for converted posts')
+  .option('-l, --log-file <path>', 'Path to log file (optional)')
+  .option('--no-skip-existing', 'Overwrite posts that already exist')
+  .option('-v, --verbose', 'Enable verbose output', false)
+  .option('-q, --quiet', 'Suppress progress output (only show summary)', false)
+  .option('-f, --flat', 'Use flat output mode ({slug}.md instead of {slug}/index.md)', false)
+  .option('--image-folder <name>', 'Image folder name in flat mode (default: _images)')
+  .option('--image-prefix <prefix>', 'Image path prefix in flat mode (default: /images)')
+  .action(async (options: CLIOptions) => {
+    await runConvert(options);
+  });
+```
+
+### 2. Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Short flag for `--flat` | `-f` | Matches convention (`-v` verbose, `-q` quiet, `-e` export, `-o` output) |
+| No short flags for `--image-folder`/`--image-prefix` | Omitted | These are less frequently used; long form is clearer |
+| `--flat` default value | `false` | Backwards compatibility; opt-in behavior |
+| No defaults for `--image-folder`/`--image-prefix` | `undefined` | Defaults applied downstream when building `OutputStructure` |
+| Help text includes defaults | Yes | Matches `--no-skip-existing` pattern of documenting defaults in description |
+
+### 3. Commander.js Naming Convention
+
+Commander.js automatically converts kebab-case to camelCase:
+
+| CLI Flag | `CLIOptions` Property | Type |
+|----------|----------------------|------|
+| `--flat` | `flat` | `boolean` |
+| `--image-folder <name>` | `imageFolder` | `string \| undefined` |
+| `--image-prefix <prefix>` | `imagePrefix` | `string \| undefined` |
+
+This matches the existing pattern: `--log-file` → `logFile`, `--skip-existing` → `skipExisting`.
+
+---
+
+## Technical Approach
+
+### 1. Option Placement
+
+New options are placed after the existing display options (`--verbose`, `--quiet`) and before `.action()`. This groups them logically:
+1. Required options (export, output)
+2. Optional path (log-file)
+3. Behavior flags (skip-existing)
+4. Display flags (verbose, quiet)
+5. **Output mode flags (flat, image-folder, image-prefix)** ← NEW
+
+### 2. Help Text Strategy
+
+Help text follows the existing pattern of being concise but informative:
+- `--flat`: Explains what changes in the output structure
+- `--image-folder`: Specifies it's for flat mode and shows the default
+- `--image-prefix`: Specifies it's for flat mode and shows the default
+
+Expected `--help` output addition:
+```
+  -f, --flat                  Use flat output mode ({slug}.md instead of {slug}/index.md)
+  --image-folder <name>       Image folder name in flat mode (default: _images)
+  --image-prefix <prefix>     Image path prefix in flat mode (default: /images)
+```
+
+---
+
+## Implementation Steps
+
+### Step 1: Add CLI Flag Definitions
+
+**File**: `src/cli/convert.ts`
+**Location**: Lines 344-345 (between `--quiet` and `.action()`)
+
+**Action**: Add three `.option()` calls
+
+**Implementation**:
+
+```typescript
+  .option('-q, --quiet', 'Suppress progress output (only show summary)', false)
+  .option('-f, --flat', 'Use flat output mode ({slug}.md instead of {slug}/index.md)', false)
+  .option('--image-folder <name>', 'Image folder name in flat mode (default: _images)')
+  .option('--image-prefix <prefix>', 'Image path prefix in flat mode (default: /images)')
+  .action(async (options: CLIOptions) => {
+```
+
+### Step 2: Add Unit Tests for Flag Registration
+
+**File**: `tests/unit/cli.test.ts`
+
+**Action**: Add tests verifying the new options are registered on the `convert` command
+
+**Implementation**:
+
+```typescript
+// ===========================================================================
+// Flat Mode CLI Flag Registration Tests
+// ===========================================================================
+describe('Flat mode CLI flags', () => {
+  it('should register --flat flag with short alias -f on convert command', () => {
+    const convertCmd = program.commands.find(cmd => cmd.name() === 'convert');
+    expect(convertCmd).toBeDefined();
+    const flatOption = convertCmd!.options.find(opt => opt.long === '--flat');
+    expect(flatOption).toBeDefined();
+    expect(flatOption!.short).toBe('-f');
+  });
+
+  it('should register --image-folder option on convert command', () => {
+    const convertCmd = program.commands.find(cmd => cmd.name() === 'convert');
+    expect(convertCmd).toBeDefined();
+    const option = convertCmd!.options.find(opt => opt.long === '--image-folder');
+    expect(option).toBeDefined();
+  });
+
+  it('should register --image-prefix option on convert command', () => {
+    const convertCmd = program.commands.find(cmd => cmd.name() === 'convert');
+    expect(convertCmd).toBeDefined();
+    const option = convertCmd!.options.find(opt => opt.long === '--image-prefix');
+    expect(option).toBeDefined();
+  });
+});
+```
+
+**Note**: Import `program` from `../../src/cli/convert.js` (already exported at line 350).
+
+---
+
+## Testing Strategy
+
+### 1. Unit Test Approach
+
+**File**: `tests/unit/cli.test.ts`
+
+**Test Categories**:
+
+#### A. Flag Registration (3 tests)
+- Test `--flat` is registered with `-f` short alias
+- Test `--image-folder` is registered as an option
+- Test `--image-prefix` is registered as an option
+
+**Total New Tests**: ~3 tests
+
+### 2. Test Coverage Targets
+
+| Metric | Target | Rationale |
+|--------|--------|-----------|
+| **Statements** | >=90% | All code paths exercised |
+| **Branches** | >=90% | Minimal branching in this step |
+| **Functions** | >=90% | No new functions added |
+| **Lines** | >=90% | Three new option lines covered by registration tests |
+
+### 3. Existing Tests
+
+All existing CLI tests (45+ tests) must continue to pass without modification. The new options are additive and do not affect existing option parsing.
+
+---
+
+## Integration Points
+
+### 1. Upstream (Input)
+- **Source**: Command-line arguments via `process.argv`
+- **Parser**: Commander.js `.option()` definitions
+- **Integration**: Commander.js auto-parses flags into `CLIOptions` object
+
+### 2. Downstream (Output)
+- **Consumer**: `runConvert(options: CLIOptions)` function
+- **Fields**: `options.flat`, `options.imageFolder`, `options.imagePrefix`
+- **Integration**: These fields are currently unused in `runConvert` (wiring happens in Step 5.3)
+
+### 3. Type Safety
+- The `CLIOptions` interface (Step 5.1) already declares these fields
+- Commander.js will populate them from parsed arguments
+- TypeScript ensures type consistency between interface and usage
+
+---
+
+## Potential Challenges & Solutions
+
+### Challenge 1: Commander.js Boolean Flag Default
+
+**Issue**: Commander.js treats boolean flags differently than value options. Without a default, `--flat` would be `undefined` when not specified.
+
+**Solution**: Provide explicit `false` default: `.option('-f, --flat', '...', false)`. This ensures `options.flat` is always `boolean`, matching the `CLIOptions` interface.
+
+**Risk Level**: Low (same pattern used for `--verbose` and `--quiet`)
+
+### Challenge 2: `--image-folder`/`--image-prefix` Without `--flat`
+
+**Issue**: Users might pass `--image-folder` without `--flat`, leading to confusion.
+
+**Solution**: Validation is handled in Step 5.3, not this step. In this step, commander.js will accept the options regardless. The values will simply be unused.
+
+**Risk Level**: Low (deferred to appropriate step)
+
+---
+
+## Success Criteria
+
+### Functional Requirements
+- `--flat` flag is parseable and defaults to `false`
+- `-f` short alias works for `--flat`
+- `--image-folder <name>` accepts a string argument
+- `--image-prefix <prefix>` accepts a string argument
+- `convert --help` shows all three new options with descriptions
+
+### Non-Functional Requirements
+- TypeScript compilation passes (`npm run type-check`)
+- Build succeeds (`npm run build`)
+- All existing tests pass (`npm test`)
+- New tests pass for flag registration
+
+### Code Quality
+- Option placement follows logical grouping
+- Help text is concise and informative
+- Follows existing `.option()` patterns
+
+---
+
+## Verification Checklist
+
+### Pre-Implementation
+- [x] GitHub Issue #55 reviewed
+- [x] Source document (IMPLEMENTATION_FLAT.md) analyzed
+- [x] CLIOptions interface verified (Step 5.1 complete)
+- [x] Commander.js option patterns studied
+- [x] Existing test patterns understood
+
+### Post-Implementation
+
+```bash
+# Verify TypeScript compilation
+nvm use $(cat .node-version) && npm run type-check
+# Expected: No TypeScript errors
+
+# Verify build succeeds
+nvm use $(cat .node-version) && npm run build
+# Expected: dist/ directory created
+
+# Run all tests
+nvm use $(cat .node-version) && npm test
+# Expected: All tests pass (existing + new)
+
+# Verify help text shows new options
+nvm use $(cat .node-version) && node dist/cli/convert.js convert --help
+# Expected: --flat, --image-folder, --image-prefix visible in help output
+```
+
+---
+
+## Git Workflow
+
+### Branch Strategy
+
+**Source Branch**: `main`
+**Implementation Branch**: `flat-output-mode/phase-5-step-5-2`
+
+### Commit Strategy
+
+**Commit Message Format**:
+```
+feat: Phase 5.2 - Add CLI flags for flat output mode
+
+- Add -f, --flat boolean flag (default: false)
+- Add --image-folder <name> option for custom image folder
+- Add --image-prefix <prefix> option for custom image path prefix
+- Add unit tests for flag registration
+
+Refs #55
+```
+
+### Pull Request
+
+- Target: `main`
+- Link to issue #55
+- Include `convert --help` output as verification
+
+---
+
+## Implementation Checklist
+
+### Phase 1: Core Implementation
+- [x] Add `.option('-f, --flat', ...)` to convert command
+- [x] Add `.option('--image-folder <name>', ...)` to convert command
+- [x] Add `.option('--image-prefix <prefix>', ...)` to convert command
+
+### Phase 2: Testing
+- [x] Import `program` in test file
+- [x] Add flag registration tests (~3 tests)
+- [x] Run all tests to verify no regressions
+
+### Phase 3: Verification
+- [x] Run `npm run type-check`
+- [x] Run `npm run build`
+- [x] Run `npm test`
+- [x] Verify `convert --help` output
+
+### Phase 4: Documentation
+- [x] Update this plan's status to COMPLETE
+- [x] Update IMPLEMENTATION_FLAT.md checkboxes for Step 5.2
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Flag naming mismatch with CLIOptions | Low | Medium | Commander.js kebab-to-camelCase conversion is well-established |
+| Breaking existing option parsing | Very Low | High | Additive change; existing options untouched |
+| Help text formatting issues | Low | Low | Follows existing option patterns |
+
+---
+
+## Timeline Estimate
+
+**Total Estimated Time**: 15-20 minutes
+
+- **Phase 1** (Core Implementation): 5 minutes
+- **Phase 2** (Testing): 5-10 minutes
+- **Phase 3** (Verification): 5 minutes
+
+---
+
+## Related Files
+
+**Files to Modify**:
+- [src/cli/convert.ts](../../../src/cli/convert.ts) - Add `.option()` calls (lines 344-345)
+- [tests/unit/cli.test.ts](../../../tests/unit/cli.test.ts) - Add flag registration tests
+
+**Files to Reference** (no changes):
+- [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) - Source requirements
+- [docs/features/flat/PHASE_5_STEP_5_1.md](PHASE_5_STEP_5_1.md) - Previous step (CLIOptions interface)
+
+---
+
+## Next Steps After Implementation
+
+1. **Step 5.3**: Build `outputStructure` from CLI Options - Add validation functions, construct `OutputStructure`, pass to `ConversionOptions`, warn if flat-only options used without `--flat`
+2. **Step 5.4**: Update Startup Display - Show output mode (nested/flat) in startup info
+3. **Step 5.5**: Write CLI Unit Tests - Comprehensive tests for flag parsing, validation, and transformation
+
+---
+
+## Summary
+
+**Phase 5.2** will deliver three new commander.js CLI option definitions that:
+- Enable `--flat` / `-f` flag parsing (boolean, defaults to `false`)
+- Enable `--image-folder <name>` option parsing (string, optional)
+- Enable `--image-prefix <prefix>` option parsing (string, optional)
+- Are verified by unit tests checking flag registration
+- Maintain backwards compatibility (additive change only)
+
+**Ready to implement?** This is a focused, low-risk step that adds the commander.js wiring for flags already defined in the `CLIOptions` interface. The changes are minimal and well-defined.

--- a/docs/features/flat/PHASE_5_STEP_5_3.md
+++ b/docs/features/flat/PHASE_5_STEP_5_3.md
@@ -1,0 +1,616 @@
+# Phase 5.3: Build outputStructure from CLI Options - Implementation Plan
+
+**Issue**: [#56 - 5.3 Build outputStructure from CLI Options](https://github.com/alvincrespo/hashnode-content-converter/issues/56)
+**Status**: IMPLEMENTED
+**Date**: 2026-02-10
+**Phase**: Phase 5 - CLI Updates, Step 5.3
+
+---
+
+## Overview
+
+Wire the parsed CLI flat-mode options (`--flat`, `--image-folder`, `--image-prefix`) into the Converter by constructing a `ConverterConfig` with `OutputStructure` and passing it through `Converter.withProgress()`. Add input validation functions to prevent path traversal, absolute paths, shell metacharacters, and XSS injection in user-provided values.
+
+**Scope**:
+- In scope: Validation functions, `OutputStructure` construction, `ConverterConfig` wiring, warning for orphaned flat-mode options, unit tests
+- Out of scope: Startup display changes (Step 5.4), comprehensive CLI end-to-end tests (Step 5.5)
+
+**Reference**: [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) (lines 1068-1232)
+
+---
+
+## Requirements Summary
+
+From [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) Phase 5, Step 5.3:
+
+- Add validation functions for `imageFolder` and `imagePrefix` (security)
+- Create `OutputStructure` object when `--flat` is set
+- Validate `imageFolder` and `imagePrefix` before use
+- Pass through to Converter via `ConverterConfig`
+- Warn if `--image-folder` or `--image-prefix` are used without `--flat`
+
+**Key Requirements**:
+- 90%+ test coverage for new code
+- Type-safe implementation (no `any` types)
+- Full JSDoc documentation on public validation functions
+- Integration with existing architecture
+
+---
+
+## Architecture Design
+
+### 1. Config vs Options Architecture
+
+`outputStructure` is an instance-level concern set on `ConverterConfig` at construction time, not a runtime option:
+
+```
+ConverterConfig.outputStructure  <-- Instance-level, set at construction
+ConversionOptions                <-- Runtime options (skipExisting, downloadOptions, loggerConfig)
+```
+
+The Converter reads `outputStructure` from `deps?.config` in its constructor ([src/converter.ts:123-124](../../../src/converter.ts#L123-L124)). The CLI passes it through `ConverterDependencies`:
+
+```typescript
+// Default (nested mode):
+const converter = Converter.withProgress(progressCallback);
+
+// Flat mode:
+const converter = Converter.withProgress(progressCallback, {
+  config: { outputStructure: { mode: 'flat', imageFolderName, imagePathPrefix } }
+});
+```
+
+### 2. Validation Functions API
+
+```typescript
+/**
+ * Validate image folder name for security.
+ * Prevents path traversal, absolute paths, and shell metacharacters.
+ * @param folder - The image folder name to validate
+ * @throws {Error} If the folder name is invalid
+ */
+export function validateImageFolder(folder: string): void;
+
+/**
+ * Validate image path prefix for markdown URLs.
+ * Ensures prefix starts with / for absolute URLs and doesn't contain injection characters.
+ * @param prefix - The image path prefix to validate
+ * @throws {Error} If the prefix is invalid
+ */
+export function validateImagePrefix(prefix: string): void;
+```
+
+### 3. Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Config placement | `ConverterDependencies.config` | Matches existing architecture; `outputStructure` is instance-level, not runtime |
+| Validation location | `src/cli/convert.ts` | CLI-level concern; keeps Converter pure |
+| Warning vs error for orphaned options | Warning (continue) | Less disruptive; user may have scripts with extra flags |
+| Validation timing | Before Converter creation | Fail fast with clear error messages |
+
+---
+
+## Technical Approach
+
+### 1. Data Flow
+
+```
+CLI args (--flat --image-folder assets --image-prefix /assets)
+    |
+    v
+commander.js parses -> CLIOptions { flat: true, imageFolder: 'assets', imagePrefix: '/assets' }
+    |
+    v
+runConvert(options)
+    |
+    +--> Warn if imageFolder/imagePrefix without --flat
+    |
+    +--> Validate imageFolder (no traversal, no absolute, no metachar)
+    +--> Validate imagePrefix (starts with /, no XSS chars, not just /)
+    |
+    +--> Build ConverterDependencies.config.outputStructure
+    |
+    v
+Converter.withProgress(callback, deps)  <-- deps includes config
+    |
+    v
+Converter constructor reads outputStructure from config
+```
+
+### 2. Implementation Strategy
+
+The changes are localized to `src/cli/convert.ts` (the `runConvert` function and new validation functions) and `tests/unit/cli.test.ts`. No changes to the Converter, types, or other files.
+
+---
+
+## Implementation Steps
+
+### Step 1: Add Validation Functions
+
+**File**: `src/cli/convert.ts`
+**Location**: After `validateMutuallyExclusiveFlags` (~line 148), before the Progress Display section
+
+**Implementation**:
+
+```typescript
+/**
+ * Validate image folder name for security.
+ * Prevents path traversal, absolute paths, and shell metacharacters.
+ *
+ * @param folder - The image folder name to validate
+ * @throws {Error} If the folder name is invalid
+ */
+export function validateImageFolder(folder: string): void {
+  if (folder.trim().length === 0) {
+    throw new Error(
+      `Invalid --image-folder: folder name cannot be empty.`
+    );
+  }
+
+  if (path.isAbsolute(folder)) {
+    throw new Error(
+      `Invalid --image-folder: "${folder}". ` +
+      `Must be a relative path (e.g., "_images", "assets").`
+    );
+  }
+
+  if (folder.includes('..')) {
+    throw new Error(
+      `Invalid --image-folder: "${folder}". ` +
+      `Path traversal (..) is not allowed for security reasons.`
+    );
+  }
+
+  if (/[<>:"|?*\x00-\x1f]/.test(folder)) {
+    throw new Error(
+      `Invalid --image-folder: "${folder}". ` +
+      `Contains invalid filesystem characters.`
+    );
+  }
+}
+
+/**
+ * Validate image path prefix for markdown URLs.
+ * Ensures prefix starts with / for absolute URLs and doesn't contain injection characters.
+ *
+ * @param prefix - The image path prefix to validate
+ * @throws {Error} If the prefix is invalid
+ */
+export function validateImagePrefix(prefix: string): void {
+  if (!prefix.startsWith('/')) {
+    throw new Error(
+      `Invalid --image-prefix: "${prefix}". ` +
+      `Must start with "/" for absolute URLs (e.g., "/images", "/assets/images").`
+    );
+  }
+
+  if (/<|>|"|'/.test(prefix)) {
+    throw new Error(
+      `Invalid --image-prefix: "${prefix}". ` +
+      `Contains invalid characters that could cause rendering issues.`
+    );
+  }
+
+  if (prefix.trim().length === 1) {
+    throw new Error(
+      `Invalid --image-prefix: prefix cannot be just "/". ` +
+      `Use a path like "/images" or "/assets".`
+    );
+  }
+}
+```
+
+### Step 2: Update Imports
+
+**File**: `src/cli/convert.ts`
+**Location**: Line 8-10 (imports section)
+
+**Action**: Add type import for `ConverterDependencies`
+
+```typescript
+import { Converter } from '../converter.js';
+import type { ConverterDependencies } from '../converter.js';
+```
+
+### Step 3: Update `runConvert` Function
+
+**File**: `src/cli/convert.ts`
+**Location**: Inside `runConvert()`, between `validateOptions()` and `conversionOptions` building (~lines 263-294)
+
+**Action**: Add warning, validation, config building, and pass deps to Converter
+
+```typescript
+async function runConvert(options: CLIOptions): Promise<void> {
+  try {
+    const validatedPaths = validateOptions(options);
+    const { exportPath, outputPath, logFilePath } = validatedPaths;
+
+    // Display startup info (unchanged)
+    // ...
+
+    // Warn if flat-mode-only options are used without --flat
+    if (!options.flat) {
+      if (options.imageFolder) {
+        console.warn('Warning: --image-folder is ignored without --flat');
+      }
+      if (options.imagePrefix) {
+        console.warn('Warning: --image-prefix is ignored without --flat');
+      }
+    }
+
+    // Build converter dependencies with output structure config
+    let converterDeps: ConverterDependencies | undefined;
+    if (options.flat) {
+      // Validate user-provided values for security
+      if (options.imageFolder) {
+        validateImageFolder(options.imageFolder);
+      }
+      if (options.imagePrefix) {
+        validateImagePrefix(options.imagePrefix);
+      }
+
+      converterDeps = {
+        config: {
+          outputStructure: {
+            mode: 'flat',
+            imageFolderName: options.imageFolder,   // undefined uses default '_images'
+            imagePathPrefix: options.imagePrefix,    // undefined uses default '/images'
+          },
+        },
+      };
+    }
+
+    // Build conversion options (unchanged)
+    const conversionOptions: ConversionOptions = {
+      skipExisting: options.skipExisting,
+    };
+
+    if (logFilePath) {
+      // ... logger config unchanged
+    }
+
+    // Create converter with progress callback and optional flat mode config
+    const progressCallback = createProgressCallback(options.quiet, options.verbose);
+    const converter = Converter.withProgress(progressCallback, converterDeps);
+
+    // Run conversion (unchanged)
+    const result = await converter.convertAllPosts(exportPath, outputPath, conversionOptions);
+
+    // ... rest unchanged
+  } catch (error) {
+    // ... unchanged
+  }
+}
+```
+
+### Step 4: Update Exports
+
+**File**: `src/cli/convert.ts`
+**Location**: Line 352 (exports)
+
+**Action**: Export the new validation functions for testing
+
+```typescript
+export { program, runConvert, validateImageFolder, validateImagePrefix };
+```
+
+### Step 5: Write Unit Tests
+
+**File**: `tests/unit/cli.test.ts`
+
+**Action**: Add test sections for validation functions and orphaned option warnings
+
+#### A. `validateImageFolder` tests (7 tests)
+
+```typescript
+describe('validateImageFolder', () => {
+  it('should accept valid relative folder names', () => {
+    expect(() => validateImageFolder('_images')).not.toThrow();
+    expect(() => validateImageFolder('assets')).not.toThrow();
+    expect(() => validateImageFolder('static/img')).not.toThrow();
+  });
+
+  it('should reject absolute paths', () => {
+    expect(() => validateImageFolder('/etc/passwd'))
+      .toThrow('Must be a relative path');
+  });
+
+  it('should reject path traversal attempts', () => {
+    expect(() => validateImageFolder('../etc'))
+      .toThrow('Path traversal (..) is not allowed');
+    expect(() => validateImageFolder('images/../../../etc'))
+      .toThrow('Path traversal (..) is not allowed');
+  });
+
+  it('should reject shell metacharacters', () => {
+    expect(() => validateImageFolder('img<script>'))
+      .toThrow('Contains invalid filesystem characters');
+    expect(() => validateImageFolder('img|rm'))
+      .toThrow('Contains invalid filesystem characters');
+    expect(() => validateImageFolder('img*'))
+      .toThrow('Contains invalid filesystem characters');
+  });
+
+  it('should reject empty folder names', () => {
+    expect(() => validateImageFolder(''))
+      .toThrow('folder name cannot be empty');
+    expect(() => validateImageFolder('   '))
+      .toThrow('folder name cannot be empty');
+  });
+
+  it('should reject names with control characters', () => {
+    expect(() => validateImageFolder('img\x00name'))
+      .toThrow('Contains invalid filesystem characters');
+  });
+
+  it('should accept hyphenated and underscored names', () => {
+    expect(() => validateImageFolder('my-images')).not.toThrow();
+    expect(() => validateImageFolder('my_images')).not.toThrow();
+  });
+});
+```
+
+#### B. `validateImagePrefix` tests (5 tests)
+
+```typescript
+describe('validateImagePrefix', () => {
+  it('should accept valid prefixes starting with /', () => {
+    expect(() => validateImagePrefix('/images')).not.toThrow();
+    expect(() => validateImagePrefix('/assets/img')).not.toThrow();
+    expect(() => validateImagePrefix('/static')).not.toThrow();
+  });
+
+  it('should reject prefixes not starting with /', () => {
+    expect(() => validateImagePrefix('images'))
+      .toThrow('Must start with "/"');
+    expect(() => validateImagePrefix('assets/images'))
+      .toThrow('Must start with "/"');
+  });
+
+  it('should reject XSS/injection characters', () => {
+    expect(() => validateImagePrefix('/img<script>'))
+      .toThrow('Contains invalid characters');
+    expect(() => validateImagePrefix('/img"onclick'))
+      .toThrow('Contains invalid characters');
+    expect(() => validateImagePrefix("/img'alert"))
+      .toThrow('Contains invalid characters');
+  });
+
+  it('should reject prefix that is just "/"', () => {
+    expect(() => validateImagePrefix('/'))
+      .toThrow('prefix cannot be just "/"');
+  });
+
+  it('should accept nested path prefixes', () => {
+    expect(() => validateImagePrefix('/assets/images/blog')).not.toThrow();
+  });
+});
+```
+
+#### C. Orphaned Options Warning Tests (2 tests)
+
+These test the warning behavior when `--image-folder` or `--image-prefix` are passed without `--flat`. Since `runConvert` calls `process.exit` and performs I/O, we need a focused testing approach. The simplest approach: since the validation+warning logic is at the start of `runConvert`, we can mock `validateOptions` to return valid paths, mock `Converter.withProgress` to return a mock converter, mock `process.exit`, and spy on `console.warn`.
+
+**Total New Tests**: ~14 tests (targeting 100% branch coverage of new code)
+
+---
+
+## Testing Strategy
+
+### 1. Unit Test Approach
+
+**File**: `tests/unit/cli.test.ts`
+
+**Test Categories**:
+
+#### A. validateImageFolder (7 tests)
+- Accepts valid names (`_images`, `assets`, `static/img`, hyphenated, underscored)
+- Rejects absolute paths
+- Rejects path traversal
+- Rejects shell metacharacters
+- Rejects empty names
+- Rejects control characters
+
+#### B. validateImagePrefix (5 tests)
+- Accepts valid prefixes
+- Rejects without leading `/`
+- Rejects XSS characters
+- Rejects just `/`
+- Accepts nested paths
+
+#### C. Orphaned Option Warnings (2 tests)
+- `--image-folder` without `--flat` warns
+- `--image-prefix` without `--flat` warns
+
+**Total Tests**: ~14 tests (targeting 100% coverage of new code)
+
+### 2. Test Coverage Targets
+
+| Metric | Target | Rationale |
+|--------|--------|-----------|
+| **Statements** | >=90% | All code paths exercised |
+| **Branches** | >=90% | All validation conditions tested |
+| **Functions** | >=90% | All new functions covered |
+| **Lines** | >=90% | Complete line coverage |
+
+---
+
+## Integration Points
+
+### 1. Upstream (Input)
+- **Source**: Commander.js parsed `CLIOptions` object
+- **Input Fields**: `options.flat`, `options.imageFolder`, `options.imagePrefix`
+- **Integration**: Values parsed by commander.js (Step 5.2)
+
+### 2. Downstream (Output)
+- **Output**: `ConverterDependencies` object with `config.outputStructure`
+- **Consumer**: `Converter.withProgress(callback, deps)` ([src/converter.ts:216-225](../../../src/converter.ts#L216-L225))
+- **Integration**: Converter constructor reads `deps.config.outputStructure` at line 123-124
+
+### 3. Error Flow
+- **Validation errors**: Thrown as `Error`, caught by `runConvert`'s try/catch, displayed to user, exits with code 1
+- **Warnings**: Written to `console.warn`, conversion proceeds normally in nested mode
+
+---
+
+## Potential Challenges & Solutions
+
+### Challenge 1: Testing `runConvert` Warning Behavior
+
+**Issue**: `runConvert` calls `process.exit()`, `validateOptions()` (which hits filesystem), and creates a real Converter. Isolating the warning behavior requires significant mocking.
+
+**Solution**: The validation functions are pure and can be tested independently with full coverage. For the warning paths, mock `validateOptions`, `Converter.withProgress`, `process.exit`, and spy on `console.warn`. If mocking proves too complex, the warning tests can be deferred to Step 5.5 (CLI integration tests).
+
+**Risk Level**: Low - validation functions cover the critical security surface area
+
+### Challenge 2: `ConverterDependencies` Import
+
+**Issue**: `ConverterDependencies` is exported from `src/converter.ts`, not from `src/types/`.
+
+**Solution**: Use type import: `import type { ConverterDependencies } from '../converter.js';`
+
+**Risk Level**: Low
+
+---
+
+## Success Criteria
+
+### Functional Requirements
+- `--flat` creates Converter with `outputStructure: { mode: 'flat' }`
+- `--flat --image-folder assets` passes `imageFolderName: 'assets'`
+- `--flat --image-prefix /static` passes `imagePathPrefix: '/static'`
+- `--image-folder` without `--flat` warns to stderr and continues in nested mode
+- Invalid `imageFolder` values rejected with descriptive error before conversion
+- Invalid `imagePrefix` values rejected with descriptive error before conversion
+- Default behavior (no `--flat`) remains unchanged
+
+### Non-Functional Requirements
+- 90%+ test coverage for new code
+- No `any` types in production code
+- All public methods documented with JSDoc
+- TypeScript compilation passes
+- Build succeeds
+- All existing tests pass
+
+### Code Quality
+- Follows existing validation function patterns in `src/cli/convert.ts`
+- Single responsibility: validation separate from config building
+- Comprehensive error messages with suggested correct usage
+
+---
+
+## Verification Checklist
+
+### Pre-Implementation
+- [x] GitHub Issue #56 reviewed
+- [x] Type definitions understood (`ConverterConfig`, `OutputStructure`, `ConverterDependencies`)
+- [x] IMPLEMENTATION_FLAT.md analyzed (lines 1068-1232)
+- [x] Converter constructor flow traced (`deps.config.outputStructure`)
+- [x] `Converter.withProgress` signature verified (accepts `deps?: ConverterDependencies`)
+- [x] Existing CLI validation patterns studied
+- [x] Existing CLI test patterns studied
+
+### Post-Implementation
+
+```bash
+# Verify TypeScript compilation
+nvm use $(cat .node-version) && npm run type-check
+# Expected: No TypeScript errors
+
+# Verify build succeeds
+nvm use $(cat .node-version) && npm run build
+# Expected: dist/ directory created
+
+# Run tests
+nvm use $(cat .node-version) && npm test
+# Expected: All tests pass
+
+# Generate coverage report
+nvm use $(cat .node-version) && npm run test:coverage
+# Expected: >=90% coverage for new code
+```
+
+---
+
+## Implementation Checklist
+
+### Phase 1: Core Implementation
+- [ ] Add `validateImageFolder` function
+- [ ] Add `validateImagePrefix` function
+- [ ] Add `ConverterDependencies` type import
+- [ ] Add orphaned option warnings to `runConvert`
+- [ ] Build `ConverterDependencies` with `config.outputStructure` when `--flat` is set
+- [ ] Pass `converterDeps` to `Converter.withProgress()`
+- [ ] Export new validation functions
+
+### Phase 2: Testing
+- [ ] Add `validateImageFolder` test suite (~7 tests)
+- [ ] Add `validateImagePrefix` test suite (~5 tests)
+- [ ] Add orphaned option warning tests (~2 tests)
+- [ ] Verify all existing tests pass
+
+### Phase 3: Verification
+- [ ] Run type-check
+- [ ] Run build
+- [ ] Run tests
+- [ ] Review coverage report
+
+### Phase 4: Documentation
+- [ ] Update IMPLEMENTATION_FLAT.md checkboxes for Step 5.3
+- [ ] Update GitHub issue #56
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| `ConverterDependencies` import issue | Low | Low | Verified export exists at src/converter.ts:28 |
+| Breaking existing CLI behavior | Very Low | High | Additive change; existing code path unchanged when `--flat` is not set |
+| Validation regex too strict/loose | Low | Medium | Based on IMPLEMENTATION_FLAT.md spec; test with edge cases |
+| Warning tests complex to mock | Medium | Low | Pure validation functions are the priority; warning tests can use existing mock patterns |
+
+---
+
+## Timeline Estimate
+
+**Total Estimated Time**: 30-45 minutes
+
+- **Phase 1** (Core Implementation): 15 minutes
+- **Phase 2** (Testing): 15-20 minutes
+- **Phase 3** (Verification): 5-10 minutes
+
+---
+
+## Related Files
+
+**Files to Modify**:
+- [src/cli/convert.ts](../../../src/cli/convert.ts) - Validation functions, `runConvert` updates, imports/exports
+- [tests/unit/cli.test.ts](../../../tests/unit/cli.test.ts) - New test suites
+
+**Files to Reference** (no changes):
+- [src/converter.ts](../../../src/converter.ts) - `Converter.withProgress()`, `ConverterDependencies` interface
+- [src/types/converter-options.ts](../../../src/types/converter-options.ts) - `OutputStructure`, `ConverterConfig` types
+- [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) - Source requirements
+
+---
+
+## Next Steps After Implementation
+
+1. **Step 5.4**: Update Startup Display - Show output mode (nested/flat) and image folder in startup info
+2. **Step 5.5**: Write CLI Unit Tests - Comprehensive end-to-end tests for flag parsing, validation, and transformation
+3. **Phase 6**: Exports and Documentation - Update public exports, README, and CHANGELOG
+
+---
+
+## Summary
+
+**Phase 5.3** will deliver the CLI-to-Converter wiring for flat output mode that:
+- Adds security validation for `imageFolder` (path traversal, absolute path, metachar prevention) and `imagePrefix` (XSS prevention, format validation)
+- Builds `ConverterConfig.outputStructure` from CLI options and passes it through `ConverterDependencies`
+- Warns users about orphaned flat-mode options (used without `--flat`)
+- Maintains backwards compatibility (no change when `--flat` is not provided)
+- Includes ~14 unit tests covering all validation branches
+
+**Ready to implement?** This plan provides focused guidance for wiring the existing CLI flags into the Converter's config system with comprehensive input validation.

--- a/docs/features/flat/PHASE_5_STEP_5_3.md
+++ b/docs/features/flat/PHASE_5_STEP_5_3.md
@@ -536,29 +536,29 @@ nvm use $(cat .node-version) && npm run test:coverage
 ## Implementation Checklist
 
 ### Phase 1: Core Implementation
-- [ ] Add `validateImageFolder` function
-- [ ] Add `validateImagePrefix` function
-- [ ] Add `ConverterDependencies` type import
-- [ ] Add orphaned option warnings to `runConvert`
-- [ ] Build `ConverterDependencies` with `config.outputStructure` when `--flat` is set
-- [ ] Pass `converterDeps` to `Converter.withProgress()`
-- [ ] Export new validation functions
+- [x] Add `validateImageFolder` function
+- [x] Add `validateImagePrefix` function
+- [x] Add `ConverterDependencies` type import
+- [x] Add orphaned option warnings to `runConvert`
+- [x] Build `ConverterDependencies` with `config.outputStructure` when `--flat` is set
+- [x] Pass `converterDeps` to `Converter.withProgress()`
+- [x] Export new validation functions
 
 ### Phase 2: Testing
-- [ ] Add `validateImageFolder` test suite (~7 tests)
-- [ ] Add `validateImagePrefix` test suite (~5 tests)
-- [ ] Add orphaned option warning tests (~2 tests)
-- [ ] Verify all existing tests pass
+- [x] Add `validateImageFolder` test suite (~7 tests)
+- [x] Add `validateImagePrefix` test suite (~5 tests)
+- [x] Add orphaned option warning tests (~2 tests)
+- [x] Verify all existing tests pass
 
 ### Phase 3: Verification
-- [ ] Run type-check
-- [ ] Run build
-- [ ] Run tests
-- [ ] Review coverage report
+- [x] Run type-check
+- [x] Run build
+- [x] Run tests
+- [x] Review coverage report
 
 ### Phase 4: Documentation
-- [ ] Update IMPLEMENTATION_FLAT.md checkboxes for Step 5.3
-- [ ] Update GitHub issue #56
+- [x] Update IMPLEMENTATION_FLAT.md checkboxes for Step 5.3
+- [x] Update GitHub issue #56
 
 ---
 

--- a/docs/features/flat/PHASE_5_STEP_5_4.md
+++ b/docs/features/flat/PHASE_5_STEP_5_4.md
@@ -1,0 +1,364 @@
+# Phase 5.4: Update CLI Startup Display for Flat Mode - Implementation Plan
+
+**Issue**: [#57 - 5.4 Update CLI Startup Display for Flat Mode](https://github.com/alvincrespo/hashnode-content-converter/issues/57)
+**Status**: ✅ IMPLEMENTED
+**Date**: 2026-02-10
+**Phase**: Phase 5 - CLI Updates, Step 5.4
+
+---
+
+## Overview
+
+Add a `Mode:` line to the CLI startup display that indicates whether the converter is running in nested or flat output mode. In flat mode, the display also shows the target image folder name. This is a small, self-contained UI enhancement that builds on the infrastructure delivered in Phases 5.1-5.3.
+
+**Scope**:
+- In scope: Mode display line in startup info, unit tests for display behavior
+- Out of scope: CLI end-to-end tests (Step 5.5), any changes to conversion logic
+
+**Reference**: [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) (lines 1242-1265)
+
+---
+
+## Requirements Summary
+
+From [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) (lines 1242-1244):
+
+- Show output mode (nested/flat) in startup info
+- Show image folder name when in flat mode
+
+**Key Requirements**:
+- 90%+ test coverage for new code
+- Type-safe implementation (no `any` types)
+- Consistent display format with existing startup lines (8-char column alignment)
+
+---
+
+## Architecture Design
+
+### Display Format
+
+The Mode line is inserted between the `Output:` and `Log:` lines, maintaining the existing 8-character label+padding alignment:
+
+**Nested Mode (default):**
+```
+Hashnode Content Converter
+Export:  /path/to/export.json
+Output:  /path/to/posts
+Mode:    nested ({slug}/index.md)
+Skip existing: true
+```
+
+**Flat Mode (default image folder):**
+```
+Hashnode Content Converter
+Export:  /path/to/export.json
+Output:  /path/to/posts
+Mode:    flat (images -> ../_images/)
+Skip existing: true
+```
+
+**Flat Mode (custom image folder):**
+```
+Hashnode Content Converter
+Export:  /path/to/export.json
+Output:  /path/to/posts
+Mode:    flat (images -> ../assets/)
+Log:     /path/to/log.txt
+Skip existing: true
+```
+
+### Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Position of Mode line | Between Output and Log | Logical grouping: input → output → structure → log → flags |
+| Default folder display | `_images` via `??` | Matches Converter default in `converter.ts:98` |
+| Show imagePrefix? | No | Mode line shows filesystem destination, not markdown URL prefix |
+| Validation ordering | Mode display before validation | Matches existing pattern (Skip existing displayed before converter config validation) |
+
+---
+
+## Implementation Steps
+
+### Step 1: Add Mode Display to Startup Info
+
+**File**: [src/cli/convert.ts](../../../src/cli/convert.ts#L339-L349)
+
+**Action**: Insert Mode conditional between the `Output:` line (line 343) and the `if (logFilePath)` check (line 344).
+
+**Current code** (lines 339-349):
+```typescript
+// Display startup info
+if (!options.quiet) {
+  console.log('\nHashnode Content Converter');
+  console.log(`Export:  ${exportPath}`);
+  console.log(`Output:  ${outputPath}`);
+  if (logFilePath) {
+    console.log(`Log:     ${logFilePath}`);
+  }
+  console.log(`Skip existing: ${options.skipExisting}`);
+  console.log('');
+}
+```
+
+**New code**:
+```typescript
+// Display startup info
+if (!options.quiet) {
+  console.log('\nHashnode Content Converter');
+  console.log(`Export:  ${exportPath}`);
+  console.log(`Output:  ${outputPath}`);
+  if (options.flat) {
+    const imageFolder = options.imageFolder ?? '_images';
+    console.log(`Mode:    flat (images -> ../${imageFolder}/)`);
+  } else {
+    console.log(`Mode:    nested ({slug}/index.md)`);
+  }
+  if (logFilePath) {
+    console.log(`Log:     ${logFilePath}`);
+  }
+  console.log(`Skip existing: ${options.skipExisting}`);
+  console.log('');
+}
+```
+
+### Step 2: Add Unit Tests
+
+**File**: [tests/unit/cli.test.ts](../../../tests/unit/cli.test.ts#L758)
+
+**Action**: Add a nested `describe('startup display Mode line', ...)` block inside the existing `describe('runConvert flat mode wiring', ...)` block (before its closing `});` at line 759). The tests inherit all existing mocks from the parent `beforeEach`.
+
+**Key detail**: Existing tests use `quiet: true` in `baseOptions`, so the new display code doesn't affect them. New tests override with `quiet: false`.
+
+```typescript
+    // =========================================================================
+    // Startup Display: Mode line
+    // =========================================================================
+    describe('startup display Mode line', () => {
+      it('should display nested mode when flat is false', async () => {
+        await runConvert({ ...baseOptions, quiet: false, flat: false });
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          'Mode:    nested ({slug}/index.md)'
+        );
+      });
+
+      it('should display flat mode with default image folder', async () => {
+        await runConvert({ ...baseOptions, quiet: false, flat: true });
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          'Mode:    flat (images -> ../_images/)'
+        );
+      });
+
+      it('should display flat mode with custom image folder', async () => {
+        await runConvert({
+          ...baseOptions,
+          quiet: false,
+          flat: true,
+          imageFolder: 'assets',
+        });
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          'Mode:    flat (images -> ../assets/)'
+        );
+      });
+
+      it('should not display Mode line when quiet is true', async () => {
+        await runConvert({ ...baseOptions, quiet: true, flat: true });
+
+        const logCalls = consoleLogSpy.mock.calls.map(call => call[0]);
+        const hasModeCall = logCalls.some(
+          (arg: unknown) => typeof arg === 'string' && (arg as string).startsWith('Mode:')
+        );
+        expect(hasModeCall).toBe(false);
+      });
+    });
+```
+
+### Step 3: Update Documentation
+
+**File**: [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md#L1242-L1244)
+
+**Action**: Mark Phase 5.4 checkboxes as complete:
+```markdown
+#### Step 5.4: Update Startup Display
+- [x] Show output mode (nested/flat) in startup info
+- [x] Show image folder name when in flat mode
+```
+
+---
+
+## Testing Strategy
+
+### Unit Tests (4 new tests)
+
+| # | Test | Options Override | Asserts |
+|---|------|-----------------|---------|
+| 1 | Nested mode display | `quiet: false, flat: false` | `Mode:    nested ({slug}/index.md)` logged |
+| 2 | Flat mode default folder | `quiet: false, flat: true` | `Mode:    flat (images -> ../_images/)` logged |
+| 3 | Flat mode custom folder | `quiet: false, flat: true, imageFolder: 'assets'` | `Mode:    flat (images -> ../assets/)` logged |
+| 4 | Quiet suppresses Mode | `quiet: true, flat: true` | No `Mode:` string in any log call |
+
+**Total Tests**: 363 existing + 4 new = 367 tests
+
+### Test Coverage Targets
+
+| Metric | Target | Rationale |
+|--------|--------|-----------|
+| **Statements** | ≥90% | Both branches (flat/nested) exercised |
+| **Branches** | ≥90% | Both `options.flat` branches + quiet guard covered |
+| **Functions** | ≥90% | No new functions added |
+| **Lines** | ≥90% | All 5 new lines covered |
+
+---
+
+## Integration Points
+
+### 1. Upstream (Input)
+- **Source**: `CLIOptions` parsed by commander.js (Phase 5.2)
+- **Input Fields**: `options.flat`, `options.imageFolder`, `options.quiet`
+- **Integration**: Values read directly from the options object
+
+### 2. Downstream (Output)
+- **Output**: Console output (informational only)
+- **Consumer**: User viewing terminal output
+- **Integration**: No downstream code dependencies
+
+### 3. Error Flow
+- **Error Handling**: None needed — display-only code inside existing `!options.quiet` guard
+- **Validation**: Image folder validation happens after display (lines 365-370), matching existing pattern
+
+---
+
+## Potential Challenges & Solutions
+
+### Challenge 1: consoleLogSpy Captures displayResult Calls Too
+
+**Issue**: `displayResult` also uses `console.log`, so the spy captures both startup display and result display calls.
+
+**Solution**: Tests assert on specific string values (`Mode:    nested...` or `Mode:    flat...`), not on call count. The "quiet suppresses Mode" test filters for `Mode:` prefix specifically.
+
+**Risk Level**: Low
+
+### Challenge 2: Validation Runs After Display
+
+**Issue**: The Mode line displays before `validateImageFolder` runs (line 366), so if validation fails, the Mode line was still shown.
+
+**Solution**: This is acceptable and matches the existing pattern. The startup display is informational; the validation error appears immediately after with a descriptive message.
+
+**Risk Level**: Low
+
+---
+
+## Success Criteria
+
+### Functional Requirements
+- [x] Nested mode shows `Mode:    nested ({slug}/index.md)` in startup info
+- [x] Flat mode shows `Mode:    flat (images -> ../_images/)` with default folder
+- [x] Flat mode with `--image-folder assets` shows `Mode:    flat (images -> ../assets/)`
+- [x] Quiet mode (`--quiet`) suppresses Mode display entirely
+- [x] Existing startup display behavior unchanged for all other lines
+
+### Non-Functional Requirements
+- [x] 90%+ test coverage for new code
+- [x] No `any` types in production code
+- [x] TypeScript compilation passes
+- [x] Build succeeds
+- [x] All 484 tests pass
+
+### Code Quality
+- [x] Follows existing startup display pattern
+- [x] Consistent 8-character column alignment
+- [x] Uses nullish coalescing (`??`) matching Converter default
+
+---
+
+## Verification Checklist
+
+### Pre-Implementation
+- [x] GitHub Issue #57 reviewed
+- [x] Current startup display code analyzed (src/cli/convert.ts:339-349)
+- [x] IMPLEMENTATION_FLAT.md spec reviewed (lines 1242-1265)
+- [x] Existing test infrastructure reviewed (cli.test.ts:631-759)
+- [x] Phase 5.3 plan reviewed for pattern consistency
+
+### Post-Implementation
+
+```bash
+# Verify TypeScript compilation
+nvm use $(cat .node-version) && npm run type-check
+# Expected: No TypeScript errors
+
+# Verify build succeeds
+nvm use $(cat .node-version) && npm run build
+# Expected: dist/ directory created
+
+# Run tests
+nvm use $(cat .node-version) && npm test
+# Expected: 367 tests pass
+
+# Generate coverage report
+nvm use $(cat .node-version) && npm run test:coverage
+# Expected: ≥90% coverage, overall ~99%
+```
+
+---
+
+## Implementation Checklist
+
+### Phase 1: Core Implementation
+- [x] Insert Mode display conditional in startup block (src/cli/convert.ts)
+
+### Phase 2: Testing
+- [x] Add `describe('startup display Mode line', ...)` with 4 tests (tests/unit/cli.test.ts)
+- [x] Verify all 484 tests pass
+
+### Phase 3: Verification
+- [x] Run type-check
+- [x] Run build
+- [x] Run tests
+- [x] Review coverage report
+
+### Phase 4: Documentation
+- [x] Mark Step 5.4 checkboxes in IMPLEMENTATION_FLAT.md
+- [x] Mark all checkboxes in PHASE_5_STEP_5_4.md implementation plan as complete and update status to ✅ IMPLEMENTED
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Display breaks existing test assertions | Very Low | Low | Existing tests use `quiet: true`; new code only runs when `quiet: false` |
+| Mode line misaligns with other labels | Low | Low | Verified 8-char column alignment matches Export/Output/Log labels |
+| imageFolder default diverges from Converter | Low | Medium | Both use `'_images'` fallback; verified in converter.ts:98 |
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| [src/cli/convert.ts](../../../src/cli/convert.ts) | Insert 5-line Mode display conditional (lines 343-347) |
+| [tests/unit/cli.test.ts](../../../tests/unit/cli.test.ts) | Add nested describe block with 4 tests |
+| [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) | Mark Phase 5.4 checkboxes as complete |
+
+---
+
+## Next Steps After Implementation
+
+1. **Step 5.5**: Write CLI Unit Tests - Comprehensive end-to-end tests for flag parsing, validation, and transformation
+2. **Phase 6**: Exports and Documentation - Update public exports, README, and CHANGELOG
+
+---
+
+## Summary
+
+**Phase 5.4** delivers a small, focused UI enhancement that:
+- Displays the active output mode (nested/flat) in the CLI startup info
+- Shows the target image folder when in flat mode (defaults to `_images`)
+- Adds 4 unit tests covering all display branches
+- Maintains full backward compatibility with existing behavior
+
+**Ready to implement?** This plan provides focused guidance for a straightforward display enhancement with comprehensive test coverage.

--- a/docs/features/flat/PHASE_6_STEP_6_1.md
+++ b/docs/features/flat/PHASE_6_STEP_6_1.md
@@ -1,0 +1,222 @@
+# Phase 6.1: Update Public Exports for Flat Mode Types - Implementation Plan
+
+**Issue**: [#59 - 6.1 Update Public Exports for Flat Mode Types](https://github.com/alvincrespo/hashnode-content-converter/issues/59)
+**Status**: ✅ IMPLEMENTED
+**Date**: 2026-02-23
+**Phase**: Phase 6 - Exports and Documentation, Step 6.1
+
+---
+
+## Context
+
+Phases 1-5 of the flat output mode feature are complete. The `OutputStructure` and `ImageProcessorContext` types were defined in Phase 1 and are used throughout the codebase. Phase 6.1 finalizes the public API by making these exports explicit and discoverable.
+
+**Current state**: Both types are technically already exported — `OutputStructure` via a wildcard `export *` and `ImageProcessorContext` via an explicit named export. However, the wildcard export for `converter-options.ts` obscures the public API surface. This phase replaces it with explicit named exports, making the API clear and intentional.
+
+---
+
+## Overview
+
+Replace the wildcard `export * from './types/converter-options.js'` in `src/index.ts` with explicit named exports that include `OutputStructure`. Verify that `ImageProcessorContext` (already explicitly exported) remains in the public API.
+
+**Scope**:
+- In scope: Converting wildcard export to explicit named exports, verification
+- Out of scope: README updates (Step 6.2), CHANGELOG (Step 6.3)
+
+---
+
+## Requirements Summary
+
+From [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) (lines 1467-1477) and [Issue #59](https://github.com/alvincrespo/hashnode-content-converter/issues/59):
+
+- Export `OutputStructure` type from `src/index.ts`
+- Export `ImageProcessorContext` type from `src/index.ts`
+
+---
+
+## Current State Analysis
+
+**File**: [src/index.ts](../../../src/index.ts)
+
+Current exports from `converter-options.ts` (line 43):
+```typescript
+export * from './types/converter-options.js';
+```
+
+This wildcard exports all 7 items from `converter-options.ts`:
+- `ImageDownloadOptions` (interface)
+- `LoggerConfig` (interface)
+- `DEFAULT_IMAGE_FOLDER` (const)
+- `OutputStructure` (interface)
+- `ConverterConfig` (interface)
+- `ConversionOptions` (interface)
+
+Current `ImageProcessorContext` export (lines 76-81):
+```typescript
+export type {
+  ImageProcessorOptions,
+  ImageProcessingResult,
+  ImageProcessingError,
+  ImageProcessorContext,  // Already exported
+} from './types/image-processor.js';
+```
+
+**Finding**: `ImageProcessorContext` is already explicitly exported. No change needed for it.
+
+---
+
+## Implementation Steps
+
+### Step 0: Create Feature Branch
+
+**Action**: Create a new branch `flat-output-mode/phase-6-step-6-1` off the current `feature/flat-output-mode` branch.
+
+```bash
+git checkout feature/flat-output-mode
+git checkout -b flat-output-mode/phase-6-step-6-1
+```
+
+### Step 1: Replace Wildcard Export with Explicit Named Exports
+
+**File**: [src/index.ts:42-44](../../../src/index.ts#L42-L44)
+
+**Action**: Replace `export * from './types/converter-options.js'` with explicit named exports.
+
+**Current code** (lines 42-44):
+```typescript
+export * from './types/converter-options.js';
+export * from './types/conversion-result.js';
+export * from './types/converter-events.js';
+```
+
+**New code**:
+```typescript
+export type {
+  ConversionOptions,
+  ConverterConfig,
+  ImageDownloadOptions,
+  LoggerConfig,
+  OutputStructure,
+} from './types/converter-options.js';
+export { DEFAULT_IMAGE_FOLDER } from './types/converter-options.js';
+export * from './types/conversion-result.js';
+export * from './types/converter-events.js';
+```
+
+**Why two export statements**: `DEFAULT_IMAGE_FOLDER` is a runtime const, not a type. TypeScript's `verbatimModuleSyntax` (enabled in this project's tsconfig) requires `export type` for type-only exports, so the const must be exported separately with a value export.
+
+### Step 2: Verify `ImageProcessorContext` Export
+
+**File**: [src/index.ts:76-81](../../../src/index.ts#L76-L81)
+
+**Action**: No code change needed. Verify that `ImageProcessorContext` remains in the existing explicit export block (line 80). Already present.
+
+### Step 3: Update Documentation
+
+**File**: [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) (lines 1467-1469)
+
+**Action**: Mark Phase 6.1 checkboxes as complete:
+```markdown
+#### Step 6.1: Update Public Exports
+- [x] Export `OutputStructure` type from `src/index.ts`
+- [x] Export `ImageProcessorContext` type from `src/index.ts`
+```
+
+---
+
+## Testing Strategy
+
+No new tests are needed. This is a re-export change with no behavioral impact. Existing tests that import from the package entry point will validate the exports still work.
+
+### Verification Commands
+
+```bash
+# Verify TypeScript compilation (catches any missing/duplicate exports)
+nvm use $(cat .node-version) && npm run type-check
+
+# Verify build succeeds
+nvm use $(cat .node-version) && npm run build
+
+# Run all tests (validates nothing broke)
+nvm use $(cat .node-version) && npm test
+```
+
+---
+
+## Potential Challenges & Solutions
+
+### Challenge 1: Wildcard May Export Items Not Listed
+
+**Issue**: If `converter-options.ts` exports items we don't enumerate, they'll be dropped from the public API.
+
+**Solution**: Verified all 6 exports from `converter-options.ts`: `ImageDownloadOptions`, `LoggerConfig`, `DEFAULT_IMAGE_FOLDER`, `OutputStructure`, `ConverterConfig`, `ConversionOptions`. All are included in the explicit exports above.
+
+**Risk Level**: Low
+
+### Challenge 2: `verbatimModuleSyntax` Requires Separate Type/Value Exports
+
+**Issue**: `DEFAULT_IMAGE_FOLDER` is a runtime value, not a type. It cannot be in an `export type {}` block.
+
+**Solution**: Use two export statements — `export type {}` for interfaces and `export {}` for the const.
+
+**Risk Level**: Low
+
+---
+
+## Success Criteria
+
+### Functional Requirements
+- [x] `OutputStructure` is importable from `@alvincrespo/hashnode-content-converter`
+- [x] `ImageProcessorContext` is importable from `@alvincrespo/hashnode-content-converter`
+- [x] All previously exported items from `converter-options.ts` remain accessible
+- [x] No duplicate exports or TypeScript errors
+
+### Non-Functional Requirements
+- [x] TypeScript compilation passes (`npm run type-check`)
+- [x] Build succeeds (`npm run build`)
+- [x] All existing tests pass (`npm test`)
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| [src/index.ts](../../../src/index.ts) | Replace `export *` with explicit named exports for converter-options.ts |
+| [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) | Mark Phase 6.1 checkboxes as complete |
+
+---
+
+## Implementation Checklist
+
+### Phase 0: Branch Setup
+- [x] Create branch `flat-output-mode/phase-6-step-1-1` off `feature/flat-output-mode`
+
+### Phase 1: Core Implementation
+- [x] Replace `export * from './types/converter-options.js'` with explicit named exports in `src/index.ts`
+
+### Phase 2: Verification
+- [x] Run type-check
+- [x] Run build
+- [x] Run tests
+
+### Phase 3: Documentation
+- [x] Mark Step 6.1 checkboxes in IMPLEMENTATION_FLAT.md
+- [x] Update this plan status to ✅ IMPLEMENTED
+
+---
+
+## Next Steps After Implementation
+
+1. **Step 6.2**: Update README — Add flat mode CLI options, usage examples, and library usage with `OutputStructure`
+2. **Step 6.3**: Update CHANGELOG — Document the flat output mode feature
+
+---
+
+## Summary
+
+**Phase 6.1** is a small, focused change that:
+- Replaces a wildcard export with explicit named exports for `converter-options.ts`
+- Makes `OutputStructure` discoverable in the public API surface
+- Confirms `ImageProcessorContext` is already explicitly exported (no change needed)
+- Preserves all existing exports with no breaking changes

--- a/docs/features/flat/PHASE_6_STEP_6_2.md
+++ b/docs/features/flat/PHASE_6_STEP_6_2.md
@@ -1,0 +1,492 @@
+# Phase 6.2: Update README for Flat Mode - Implementation Plan
+
+**Issue**: [#60 - 6.2 Update README for Flat Mode](https://github.com/alvincrespo/hashnode-content-converter/issues/60)
+**Status**: ✅ IMPLEMENTED
+**Date**: 2026-02-23
+**Phase**: Phase 6 - Exports and Documentation, Step 6.2
+
+---
+
+## Context
+
+All code implementation for the flat output mode feature is complete (Phases 1-5, 6.1). The README currently has no mention of flat mode, the `--flat` CLI flag, or the `outputStructure` programmatic API. This phase updates README.md to document the entire flat output mode feature for both CLI and library users.
+
+---
+
+## Overview
+
+Update README.md with seven discrete edits to document the flat output mode feature: add it to the Features list, add new CLI options to the options table, create an "Output Modes" section with directory tree comparisons and usage examples, add a programmatic API example showing `outputStructure` configuration, and update the migration section.
+
+**Scope**:
+- In scope: All README edits for flat mode documentation
+- Out of scope: CHANGELOG updates (Step 6.3), external docs site updates
+
+**Reference**: [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) (lines 1479-1483)
+
+---
+
+## Requirements Summary
+
+From [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) (lines 1479-1483) and [Issue #60](https://github.com/alvincrespo/hashnode-content-converter/issues/60):
+
+- Add flat mode to CLI options table
+- Add flat mode usage examples
+- Document `--image-folder` and `--image-prefix` options
+- Add library usage example with `outputStructure`
+- Explain when to use flat vs nested mode
+
+**Key Requirements**:
+- All code examples must use correct API signatures
+- Maintain consistent documentation style with existing README
+- Section flow should read naturally for new users
+
+---
+
+## Critical Files
+
+| File | Action |
+|------|--------|
+| [README.md](../../../README.md) | Edit (sole deliverable) |
+| [src/converter.ts](../../../src/converter.ts) | Reference for API signatures |
+| [src/types/converter-options.ts](../../../src/types/converter-options.ts) | Reference for `OutputStructure` type |
+| [src/cli/convert.ts](../../../src/cli/convert.ts) | Reference for CLI flag names/defaults |
+| [docs/IMPLEMENTATION_FLAT.md](../../IMPLEMENTATION_FLAT.md) | Mark Step 6.2 checkboxes complete |
+
+---
+
+## Architecture Design
+
+### API Signatures Reference
+
+The following API signatures were verified from source code and must be used correctly in documentation examples:
+
+#### Constructor Pattern
+```typescript
+// ConverterDependencies (src/converter.ts:29-42)
+interface ConverterDependencies {
+  config?: ConverterConfig;
+  // ...other optional deps
+}
+
+// ConverterConfig (src/types/converter-options.ts)
+interface ConverterConfig {
+  outputStructure?: OutputStructure;
+}
+
+// OutputStructure (src/types/converter-options.ts)
+interface OutputStructure {
+  mode: 'nested' | 'flat';
+  imageFolderName?: string;   // default: '_images'
+  imagePathPrefix?: string;   // default: '/images'
+}
+
+// Usage:
+new Converter({ config: { outputStructure: { mode: 'flat' } } })
+```
+
+#### Static Factory Pattern
+```typescript
+// Converter.fromExportFile (src/converter.ts:181-189)
+static async fromExportFile(
+  exportPath: string,
+  outputDir: string,
+  options?: ConversionOptions,    // 3rd param: runtime options
+  config?: ConverterConfig        // 4th param: instance config
+): Promise<ConversionResult>
+```
+
+#### CLI Flags
+```typescript
+// src/cli/convert.ts:448-459
+.option('-f, --flat', '...', false)
+.option('--image-folder <name>', '...')
+.option('--image-prefix <prefix>', '...')
+```
+
+---
+
+## Implementation Steps
+
+### Step 0: Create Feature Branch
+
+**Action**: Create a new branch `flat-output-mode/phase-6-step-6-2` off the current `feature/flat-output-mode` branch.
+
+```bash
+git checkout feature/flat-output-mode
+git checkout -b flat-output-mode/phase-6-step-6-2
+```
+
+### README Edits
+
+All edits target `README.md`. Apply edits **bottom-to-top** to preserve line number accuracy (each insertion shifts subsequent lines).
+
+### Edit 1: Add Flat Mode to Features List
+
+**File**: `README.md`
+
+**Location**: After line 14 (the "Image Localization" bullet)
+
+**Action**: Insert one new bullet point for flat output mode.
+
+**Implementation**:
+
+```markdown
+- **Flat Output Mode**: Optional `--flat` flag creates `{slug}.md` files with shared image folder, ideal for Bridgetown, Jekyll, and Hugo
+```
+
+---
+
+### Edit 2: Add Three New Rows to CLI Options Table
+
+**File**: `README.md`
+
+**Location**: After line 65 (the `--quiet` row in the options table)
+
+**Action**: Add three new rows for `--flat`, `--image-folder`, and `--image-prefix`.
+
+**Implementation**:
+
+```markdown
+| `--flat` | `-f` | Use flat output mode (`{slug}.md` instead of `{slug}/index.md`) | `false` |
+| `--image-folder <name>` | | Image folder name (flat mode only) | `_images` |
+| `--image-prefix <prefix>` | | Image path prefix in markdown (flat mode only) | `/images` |
+```
+
+---
+
+### Edit 3: Add "Output Modes" Section
+
+**File**: `README.md`
+
+**Location**: After line 69 (the Exit Codes block), before "Programmatic API" (line 71). New subsection under "Usage > CLI".
+
+**Action**: Create a comprehensive "Output Modes" section with directory tree comparisons, CLI usage examples, and a "When to Use Each Mode" comparison table.
+
+**Implementation**:
+
+```markdown
+### Output Modes
+
+The converter supports two output modes for organizing posts and images.
+
+#### Nested Mode (Default)
+
+Each post gets its own directory with images alongside:
+
+```
+output/
+├── my-first-post/
+│   ├── index.md          # Image refs: ./image.png
+│   └── image.png
+├── my-second-post/
+│   ├── index.md
+│   └── screenshot.png
+```
+
+#### Flat Mode (`--flat`)
+
+Standalone `.md` files with images in a shared sibling folder:
+
+```bash
+npx @alvincrespo/hashnode-content-converter convert \
+  --export ./export.json \
+  --output ./src/_posts \
+  --flat
+```
+
+```
+src/
+├── _posts/
+│   ├── my-first-post.md      # Image refs: /images/image.png
+│   └── my-second-post.md
+└── _images/
+    ├── image.png
+    └── screenshot.png
+```
+
+Customize the image folder and path prefix for your framework:
+
+```bash
+# Hugo-style assets
+npx @alvincrespo/hashnode-content-converter convert \
+  --export ./export.json \
+  --output ./content/posts \
+  --flat \
+  --image-folder assets \
+  --image-prefix /assets
+```
+
+#### When to Use Each Mode
+
+| Criteria | Nested (default) | Flat (`--flat`) |
+|----------|-------------------|-----------------|
+| **Best for** | Self-contained posts | Bridgetown, Jekyll, Hugo, Next.js |
+| **Post files** | `{slug}/index.md` | `{slug}.md` |
+| **Image location** | Per-post directory | Shared sibling folder |
+| **Image paths** | Relative (`./image.png`) | Absolute (`/images/image.png`) |
+| **Image deduplication** | No (per-post copies) | Yes (shared folder) |
+```
+
+---
+
+### Edit 4: Add Flat Mode Programmatic API Subsection
+
+**File**: `README.md`
+
+**Location**: After the "Quick Start" subsection (after line 83), before "With Progress Tracking" (line 85).
+
+**Action**: Add a new `#### Flat Mode` subsection showing the constructor pattern and static factory pattern.
+
+**Implementation**:
+
+```markdown
+#### Flat Mode
+
+Configure flat output mode at the instance level via `ConverterConfig`:
+
+```typescript
+import { Converter } from '@alvincrespo/hashnode-content-converter';
+
+// Flat mode with default settings (_images folder, /images prefix)
+const converter = new Converter({
+  config: {
+    outputStructure: { mode: 'flat' },
+  },
+});
+const result = await converter.convertAllPosts('./export.json', './src/_posts');
+
+// Flat mode with custom image settings (e.g., for Hugo)
+const hugoConverter = new Converter({
+  config: {
+    outputStructure: {
+      mode: 'flat',
+      imageFolderName: 'assets',
+      imagePathPrefix: '/assets',
+    },
+  },
+});
+await hugoConverter.convertAllPosts('./export.json', './content/posts');
+```
+
+Or use the static factory method:
+
+```typescript
+const result = await Converter.fromExportFile(
+  './export.json',
+  './src/_posts',
+  { skipExisting: true },                    // ConversionOptions
+  { outputStructure: { mode: 'flat' } }      // ConverterConfig
+);
+```
+```
+
+---
+
+### Edit 5: Update Migration "Output Format" Note
+
+**File**: `README.md`
+
+**Location**: Lines 369-373
+
+**Action**: Update the output format bullet to mention flat mode option.
+
+**Current**:
+```markdown
+3. **Output format**: The generated Markdown files maintain the same structure:
+   - YAML frontmatter with title, date, description, cover image
+   - Cleaned markdown content (align attributes removed)
+   - Downloaded images in post directories
+```
+
+**New**:
+```markdown
+3. **Output format**: The generated Markdown files maintain the same structure by default:
+   - YAML frontmatter with title, date, description, cover image
+   - Cleaned markdown content (align attributes removed)
+   - Downloaded images in post directories (nested mode, default)
+   - Or use `--flat` for standalone `.md` files with shared image folder (see [Output Modes](#output-modes))
+```
+
+---
+
+### Edit 6: Update Migration Configuration Table
+
+**File**: `README.md`
+
+**Location**: Line 349 (last row of the comparison table)
+
+**Action**: Replace `Same output format, more control` with `Nested (default) or flat mode (\`--flat\`)`.
+
+**Current**:
+```markdown
+| Single output format | Same output format, more control |
+```
+
+**New**:
+```markdown
+| Single output format | Nested (default) or flat mode (`--flat`) |
+```
+
+---
+
+### Edit 7: Update IMPLEMENTATION_FLAT.md Checkboxes
+
+**File**: `docs/IMPLEMENTATION_FLAT.md`
+
+**Location**: Lines 1479-1483
+
+**Action**: Mark all Step 6.2 checkboxes as complete.
+
+**Current**:
+```markdown
+#### Step 6.2: Update README
+- [ ] Add flat mode to CLI options table
+- [ ] Add flat mode usage example
+- [ ] Document `--image-folder` and `--image-prefix` options
+- [ ] Add library usage example with `outputStructure`
+```
+
+**New**:
+```markdown
+#### Step 6.2: Update README
+- [x] Add flat mode to CLI options table
+- [x] Add flat mode usage example
+- [x] Document `--image-folder` and `--image-prefix` options
+- [x] Add library usage example with `outputStructure`
+```
+
+---
+
+## Testing Strategy
+
+This is a documentation-only change. No new tests are needed.
+
+### Verification Commands
+
+```bash
+# Verify build still passes (catches any accidental file issues)
+nvm use $(cat .node-version) && npm run build
+
+# Verify all tests still pass
+nvm use $(cat .node-version) && npm test
+```
+
+### Manual Verification Checklist
+- [x] All code examples use correct API signatures
+- [x] `#output-modes` anchor link resolves from migration section
+- [x] CLI options table aligns properly with new rows
+- [x] Directory tree examples use consistent formatting
+- [x] No heading level jumps (maintains `###` -> `####` hierarchy)
+- [x] README renders correctly in markdown preview
+
+---
+
+## Potential Challenges & Solutions
+
+### Challenge 1: Anchor Link Resolution
+
+**Issue**: The `[Output Modes](#output-modes)` link in Edit 5 depends on the heading created in Edit 3. If the heading text changes, the link breaks.
+
+**Solution**: Ensure the heading is exactly `### Output Modes` which generates the `#output-modes` anchor. Apply Edit 3 before Edit 5.
+
+**Risk Level**: Low
+
+### Challenge 2: Code Example Accuracy
+
+**Issue**: Code examples must match actual API signatures. Incorrect examples mislead users.
+
+**Solution**: All signatures verified from source:
+- `new Converter({ config: { outputStructure: ... } })` — verified from `src/converter.ts:120`
+- `Converter.fromExportFile(path, dir, options?, config?)` — verified from `src/converter.ts:181-189`
+- CLI flags verified from `src/cli/convert.ts:448-459`
+
+**Risk Level**: Low
+
+### Challenge 3: Table Formatting Alignment
+
+**Issue**: Adding three rows to the CLI options table may cause column misalignment if cell widths vary.
+
+**Solution**: Verify markdown table renders correctly in preview. The `--image-folder <name>` cell is longer than existing cells, but markdown tables handle this gracefully.
+
+**Risk Level**: Low
+
+---
+
+## Success Criteria
+
+### Functional Requirements
+- [x] Flat mode mentioned in Features list
+- [x] `--flat`, `--image-folder`, `--image-prefix` in CLI options table with correct defaults
+- [x] Output Modes section with nested/flat directory tree comparison
+- [x] CLI usage examples for flat mode (basic and custom config)
+- [x] "When to Use Each Mode" comparison table
+- [x] Programmatic API examples (constructor and static factory patterns)
+- [x] Migration section updated with flat mode mention
+
+### Non-Functional Requirements
+- [x] All code examples use verified API signatures
+- [x] Markdown formatting renders correctly
+- [x] Section flow reads naturally for new users
+- [x] Build and tests still pass
+
+### Code Quality
+- [x] Consistent documentation style with existing README
+- [x] No broken anchor links
+- [x] Proper heading hierarchy
+
+---
+
+## Implementation Checklist
+
+### Phase 0: Branch Setup
+- [x] Create branch `flat-output-mode/phase-6-step-6-2` off `feature/flat-output-mode`
+
+### Phase 1: README Edits (bottom-to-top order to preserve line numbers)
+- [x] Edit 6: Update migration config table (line 349)
+- [x] Edit 5: Update migration output format note (lines 369-373)
+- [x] Edit 4: Add flat mode programmatic API subsection (after line 83)
+- [x] Edit 3: Add Output Modes section (after line 69)
+- [x] Edit 2: Add CLI options table rows (after line 65)
+- [x] Edit 1: Add Features list bullet (after line 14)
+
+### Phase 2: Documentation Updates
+- [x] Edit 7: Mark Step 6.2 checkboxes in IMPLEMENTATION_FLAT.md
+
+### Phase 3: Verification
+- [x] Run build
+- [x] Run tests
+- [x] Visual review of README formatting
+
+### Phase 4: Commit, Push, and PR
+- [x] Stage changed files (`README.md`, `docs/IMPLEMENTATION_FLAT.md`)
+- [x] Commit with descriptive message
+- [x] Push branch to origin
+- [x] Open pull request targeting `feature/flat-output-mode` for review
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Broken anchor link | Low | Low | Verify heading text matches link target |
+| Incorrect API signatures | Low | Medium | All verified from source code |
+| Table formatting issues | Low | Low | Preview markdown before committing |
+
+---
+
+## Next Steps After Implementation
+
+1. **Step 6.3**: Update CHANGELOG — Document the flat output mode feature
+2. **Release**: Once all Phase 6 steps are complete, cut a release with the flat mode feature
+
+---
+
+## Summary
+
+**Phase 6.2** will deliver comprehensive README documentation for the flat output mode feature that:
+- Makes flat mode discoverable via the Features list and CLI options table
+- Provides clear visual comparison of nested vs flat output structures
+- Includes ready-to-use CLI commands and programmatic API examples
+- Updates the migration guide to inform existing users about the new option
+- Uses verified API signatures to ensure accuracy

--- a/src/cli/convert.ts
+++ b/src/cli/convert.ts
@@ -33,6 +33,12 @@ interface CLIOptions {
   verbose: boolean;
   /** Suppress progress output */
   quiet: boolean;
+  /** Enable flat output mode ({slug}.md instead of {slug}/index.md) */
+  flat: boolean;
+  /** Image folder name in flat mode (default: _images) */
+  imageFolder?: string;
+  /** Image path prefix in flat mode (default: /images) */
+  imagePrefix?: string;
 }
 
 /**

--- a/src/cli/convert.ts
+++ b/src/cli/convert.ts
@@ -342,6 +342,9 @@ program
   .option('--no-skip-existing', 'Overwrite posts that already exist')
   .option('-v, --verbose', 'Enable verbose output', false)
   .option('-q, --quiet', 'Suppress progress output (only show summary)', false)
+  .option('-f, --flat', 'Use flat output mode ({slug}.md instead of {slug}/index.md)', false)
+  .option('--image-folder <name>', 'Image folder name in flat mode (default: _images)')
+  .option('--image-prefix <prefix>', 'Image path prefix in flat mode (default: /images)')
   .action(async (options: CLIOptions) => {
     await runConvert(options);
   });

--- a/src/cli/convert.ts
+++ b/src/cli/convert.ts
@@ -7,6 +7,7 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Converter } from '../converter.js';
 import type { ConverterDependencies } from '../converter.js';
+import { DEFAULT_IMAGE_FOLDER } from '../types/converter-options.js';
 import type { ConversionOptions, LoggerConfig } from '../types/converter-options.js';
 import type { ConversionResult } from '../types/conversion-result.js';
 
@@ -341,6 +342,12 @@ async function runConvert(options: CLIOptions): Promise<void> {
       console.log('\nHashnode Content Converter');
       console.log(`Export:  ${exportPath}`);
       console.log(`Output:  ${outputPath}`);
+      if (options.flat) {
+        const imageFolder = options.imageFolder ?? DEFAULT_IMAGE_FOLDER;
+        console.log(`Mode:    flat (images -> ../${imageFolder}/)`);
+      } else {
+        console.log(`Mode:    nested ({slug}/index.md)`);
+      }
       if (logFilePath) {
         console.log(`Log:     ${logFilePath}`);
       }

--- a/src/cli/convert.ts
+++ b/src/cli/convert.ts
@@ -6,6 +6,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Converter } from '../converter.js';
+import type { ConverterDependencies } from '../converter.js';
 import type { ConversionOptions, LoggerConfig } from '../types/converter-options.js';
 import type { ConversionResult } from '../types/conversion-result.js';
 
@@ -147,6 +148,78 @@ export function validateMutuallyExclusiveFlags(verbose: boolean, quiet: boolean)
 }
 
 /**
+ * Validate image folder name for security.
+ * Prevents path traversal, absolute paths, and shell metacharacters.
+ *
+ * @param folder - The image folder name to validate
+ * @throws {Error} If the folder name is invalid
+ */
+export function validateImageFolder(folder: string): void {
+  // Prevent empty folder name
+  if (folder.trim().length === 0) {
+    throw new Error(
+      `Invalid --image-folder: folder name cannot be empty.`
+    );
+  }
+
+  // Prevent absolute paths - image folder must be relative
+  if (path.isAbsolute(folder)) {
+    throw new Error(
+      `Invalid --image-folder: "${folder}". ` +
+      `Must be a relative path (e.g., "_images", "assets").`
+    );
+  }
+
+  // Prevent path traversal attacks
+  if (folder.includes('..')) {
+    throw new Error(
+      `Invalid --image-folder: "${folder}". ` +
+      `Path traversal (..) is not allowed for security reasons.`
+    );
+  }
+
+  // Reject characters that could be misinterpreted in shell contexts
+  // (< > | * ? for globbing/redirection/piping, : " for quoting),
+  // plus control characters (U+0000–U+001F) which are not valid in filenames.
+  const hasInvalidChars = /[<>:"|?*]/.test(folder);
+  const hasControlChars = [...folder].some(c => c.charCodeAt(0) <= 0x1f);
+  if (hasInvalidChars || hasControlChars) {
+    throw new Error(
+      `Invalid --image-folder: "${folder}". ` +
+      `Contains invalid filesystem characters.`
+    );
+  }
+}
+
+/**
+ * Validate image path prefix for markdown URLs.
+ * Ensures prefix starts with / for absolute URLs and doesn't contain injection characters.
+ *
+ * @param prefix - The image path prefix to validate
+ * @throws {Error} If the prefix is invalid
+ */
+export function validateImagePrefix(prefix: string): void {
+  // imagePrefix must start with / for absolute URLs in markdown
+  if (!prefix.startsWith('/')) {
+    throw new Error(
+      `Invalid --image-prefix: "${prefix}". ` +
+      `Must start with "/" for absolute URLs (e.g., "/images", "/assets/images").`
+    );
+  }
+
+  // Allowlist: only permit characters safe for URL paths and markdown link
+  // destinations. The prefix is interpolated into ![alt](prefix/file.png),
+  // so characters like ), whitespace, or control chars could break markdown
+  // parsing or enable injection.
+  if (!/^\/[A-Za-z0-9._\-/]+$/.test(prefix)) {
+    throw new Error(
+      `Invalid --image-prefix: "${prefix}". ` +
+      `Only alphanumeric characters, hyphens, underscores, dots, and forward slashes are allowed.`
+    );
+  }
+}
+
+/**
  * Validate all CLI options by delegating to specific validators
  * @param options - Parsed CLI options
  * @returns Validated and resolved paths
@@ -275,6 +348,38 @@ async function runConvert(options: CLIOptions): Promise<void> {
       console.log('');
     }
 
+    // Warn if flat-mode-only options are used without --flat
+    if (!options.flat) {
+      if (options.imageFolder) {
+        console.warn('Warning: --image-folder is ignored without --flat');
+      }
+      if (options.imagePrefix) {
+        console.warn('Warning: --image-prefix is ignored without --flat');
+      }
+    }
+
+    // Build converter dependencies with output structure config
+    let converterDeps: ConverterDependencies | undefined;
+    if (options.flat) {
+      // Validate user-provided values for security
+      if (options.imageFolder) {
+        validateImageFolder(options.imageFolder);
+      }
+      if (options.imagePrefix) {
+        validateImagePrefix(options.imagePrefix);
+      }
+
+      converterDeps = {
+        config: {
+          outputStructure: {
+            mode: 'flat',
+            imageFolderName: options.imageFolder,   // undefined uses default '_images'
+            imagePathPrefix: options.imagePrefix,    // undefined uses default '/images'
+          },
+        },
+      };
+    }
+
     // Build conversion options
     const conversionOptions: ConversionOptions = {
       skipExisting: options.skipExisting,
@@ -289,9 +394,9 @@ async function runConvert(options: CLIOptions): Promise<void> {
       conversionOptions.loggerConfig = loggerConfig;
     }
 
-    // Create converter with progress callback
+    // Create converter with progress callback and optional flat mode config
     const progressCallback = createProgressCallback(options.quiet, options.verbose);
-    const converter = Converter.withProgress(progressCallback);
+    const converter = Converter.withProgress(progressCallback, converterDeps);
 
     // Run conversion
     const result = await converter.convertAllPosts(exportPath, outputPath, conversionOptions);

--- a/src/cli/convert.ts
+++ b/src/cli/convert.ts
@@ -467,7 +467,20 @@ export type { CLIOptions, ValidatedOptions };
 
 // Parse arguments and execute only when run directly (not imported)
 // ESM equivalent of require.main === module
-const isMainModule = process.argv[1] === fileURLToPath(import.meta.url);
-if (isMainModule) {
+// Use fs.realpathSync to resolve symlinks (e.g., npm link creates symlinked binaries)
+function checkIsMainModule(): boolean {
+  try {
+    const argv1 = fs.realpathSync(process.argv[1]);
+    const thisFile = fs.realpathSync(fileURLToPath(import.meta.url));
+    // Guard against mocked fs returning undefined in test environments
+    if (!argv1 || !thisFile) return false;
+    return argv1 === thisFile;
+  } catch {
+    // Fallback to direct comparison if realpathSync fails
+    return process.argv[1] === fileURLToPath(import.meta.url);
+  }
+}
+
+if (checkIsMainModule()) {
   program.parse();
 }

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -8,6 +8,7 @@ import { ImageProcessor } from './processors/image-processor.js';
 import { FrontmatterGenerator } from './processors/frontmatter-generator.js';
 import { FileWriter } from './services/file-writer.js';
 import { Logger } from './services/logger.js';
+import { Post } from './models/post.js';
 
 import type { HashnodePost, HashnodeExport, PostMetadata } from './types/hashnode-schema.js';
 import type { ConversionOptions, OutputStructure, ConverterConfig } from './types/converter-options.js';
@@ -332,7 +333,7 @@ export class Converter extends EventEmitter {
           const skipResult: ConvertedPost = {
             slug,
             title: post.title || slug,
-            outputPath: path.join(outputDir, slug, 'index.md'),
+            outputPath: this.getSkipOutputPath(outputDir, slug),
             success: true,
           };
           const completeEvent: ConversionCompletedEvent = {
@@ -853,5 +854,32 @@ export class Converter extends EventEmitter {
       .forEach((err) => {
         this.logger?.trackHttp403(slug, err.filename, err.url);
       });
+  }
+
+  /**
+   * Get the output path for a skipped post based on output mode.
+   * Creates a temporary Post instance to compute the correct path.
+   *
+   * @param outputDir - Base output directory
+   * @param slug - Post slug
+   * @returns Full path to the markdown file
+   */
+  private getSkipOutputPath(outputDir: string, slug: string): string {
+    try {
+      const outputMode = this.outputStructure.mode === 'flat' ? 'flat' : 'nested';
+      const tempPost = new Post({
+        slug,
+        frontmatter: '',
+        content: '',
+        outputMode,
+      });
+      return tempPost.getFilePath(outputDir);
+    } catch (error) {
+      // Fallback to nested format for invalid slugs
+      // This should rarely happen since postExists() validates first
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      this.logger?.warn(`Failed to compute skip path for slug "${slug}": ${errorMsg}. Using nested format fallback.`);
+      return path.join(outputDir, slug, 'index.md');
+    }
   }
 }

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -9,8 +9,8 @@ import { FrontmatterGenerator } from './processors/frontmatter-generator.js';
 import { FileWriter } from './services/file-writer.js';
 import { Logger } from './services/logger.js';
 
-import type { HashnodePost, HashnodeExport } from './types/hashnode-schema.js';
-import type { ConversionOptions } from './types/converter-options.js';
+import type { HashnodePost, HashnodeExport, PostMetadata } from './types/hashnode-schema.js';
+import type { ConversionOptions, OutputStructure, ConverterConfig } from './types/converter-options.js';
 import type { ConversionResult, ConvertedPost, ConversionError } from './types/conversion-result.js';
 import type {
   ConverterEventMap,
@@ -19,6 +19,7 @@ import type {
   ImageDownloadedEvent,
   ConversionErrorEvent,
 } from './types/converter-events.js';
+import type { ImageProcessingResult } from './types/image-processor.js';
 
 /**
  * Optional dependencies for testing via dependency injection
@@ -30,6 +31,12 @@ export interface ConverterDependencies {
   frontmatterGenerator?: FrontmatterGenerator;
   fileWriter?: FileWriter;
   logger?: Logger;
+
+  /**
+   * Instance-level configuration (output structure, etc.)
+   * Separate from runtime ConversionOptions
+   */
+  config?: ConverterConfig;
 }
 
 /**
@@ -69,12 +76,39 @@ export interface ConverterDependencies {
  * ```
  */
 export class Converter extends EventEmitter {
+  /**
+   * Default dependencies used when not provided via dependency injection.
+   * Creates fresh instances on each access to avoid shared state between Converter instances.
+   */
+  private static get DEFAULTS(): Required<Omit<ConverterDependencies, 'logger' | 'config'>> {
+    return {
+      postParser: new PostParser(),
+      markdownTransformer: new MarkdownTransformer(),
+      imageProcessor: new ImageProcessor(),
+      frontmatterGenerator: new FrontmatterGenerator(),
+      fileWriter: new FileWriter(),
+    };
+  }
+
+  /**
+   * Default configuration when not provided.
+   */
+  private static readonly DEFAULT_CONFIG: Required<ConverterConfig> = {
+    outputStructure: { mode: 'nested' },
+  };
+
   private postParser: PostParser;
   private markdownTransformer: MarkdownTransformer;
   private imageProcessor: ImageProcessor;
   private frontmatterGenerator: FrontmatterGenerator;
   private fileWriter: FileWriter;
   private logger: Logger | null = null;
+
+  /**
+   * Output structure configuration set at instance creation.
+   * Determines file naming and image storage location.
+   */
+  private readonly outputStructure: OutputStructure;
 
   /**
    * Create a new Converter instance.
@@ -84,17 +118,35 @@ export class Converter extends EventEmitter {
   constructor(deps?: ConverterDependencies) {
     super();
 
-    // Initialize processors and services (use injected or create new)
-    this.postParser = deps?.postParser ?? new PostParser();
-    this.markdownTransformer = deps?.markdownTransformer ?? new MarkdownTransformer();
-    this.imageProcessor = deps?.imageProcessor ?? new ImageProcessor();
-    this.frontmatterGenerator = deps?.frontmatterGenerator ?? new FrontmatterGenerator();
-    this.fileWriter = deps?.fileWriter ?? new FileWriter();
+    // Resolve config with defaults
+    const config = { ...Converter.DEFAULT_CONFIG, ...deps?.config };
+    this.outputStructure = config.outputStructure;
 
-    // Logger is initialized per-conversion in convertAllPosts
-    // to allow fresh timestamp and configuration
-    if (deps?.logger) {
-      this.logger = deps.logger;
+    // Determine output mode based on config
+    const outputMode = this.outputStructure.mode === 'flat' ? 'flat' : 'nested';
+
+    // Resolve dependencies with defaults
+    // FileWriter is configured once at construction with the instance's output mode.
+    // This single instance is used for all conversions, ensuring consistent file naming
+    // (flat: slug.md, nested: slug/index.md) throughout the instance's lifetime.
+    const defaultFileWriter = new FileWriter({ outputMode });
+    const resolved = {
+      ...Converter.DEFAULTS,
+      fileWriter: defaultFileWriter,
+      ...deps, // User-provided deps override everything
+    };
+
+    // Assign resolved dependencies
+    this.postParser = resolved.postParser;
+    this.markdownTransformer = resolved.markdownTransformer;
+    this.imageProcessor = resolved.imageProcessor;
+    this.frontmatterGenerator = resolved.frontmatterGenerator;
+    this.fileWriter = resolved.fileWriter;
+
+    // Logger is optional (can be null)
+    // Initialized per-conversion in convertAllPosts to allow fresh timestamp and configuration
+    if (resolved.logger) {
+      this.logger = resolved.logger;
     }
   }
 
@@ -127,9 +179,10 @@ export class Converter extends EventEmitter {
   static async fromExportFile(
     exportPath: string,
     outputDir: string,
-    options?: ConversionOptions
+    options?: ConversionOptions,
+    config?: ConverterConfig
   ): Promise<ConversionResult> {
-    const converter = new Converter();
+    const converter = new Converter({ config });
     return converter.convertAllPosts(exportPath, outputDir, options);
   }
 
@@ -379,79 +432,264 @@ export class Converter extends EventEmitter {
   ): Promise<ConvertedPost> {
     const slug = this.extractSlugSafely(post, 0);
 
-    try {
-      // Step 1: Parse post metadata
-      const metadata = this.postParser.parse(post);
-
-      // Step 2: Transform markdown (remove Hashnode quirks)
-      const transformedMarkdown = this.markdownTransformer.transform(metadata.contentMarkdown);
-
-      // Step 3: Create post directory (required by ImageProcessor)
-      const postDir = path.join(outputDir, metadata.slug);
-      if (!fs.existsSync(postDir)) {
-        fs.mkdirSync(postDir, { recursive: true });
-      }
-
-      // Step 4: Process images (download and replace URLs)
-      const imageProcessor =
-        options?.downloadOptions
-          ? new ImageProcessor(options.downloadOptions)
-          : this.imageProcessor;
-
-      const imageResult = await imageProcessor.process(transformedMarkdown, postDir);
-
-      // Emit image-downloaded events
-      this.emitImageDownloadedEvents(imageResult, metadata.slug);
-
-      // Track HTTP 403 errors with Logger
-      this.trackHttp403Errors(imageResult.errors, metadata.slug);
-
-      // Step 5: Generate frontmatter
-      const frontmatter = this.frontmatterGenerator.generate(metadata);
-
-      // Step 6: Write file
-      const outputPath = await this.fileWriter.writePost(
-        outputDir,
-        metadata.slug,
-        frontmatter,
-        imageResult.markdown
-      );
-
-      return {
-        slug: metadata.slug,
-        title: metadata.title,
-        outputPath,
-        success: true,
-      };
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-
-      // Determine error type based on error source
-      let errorType: ConversionErrorEvent['type'] = 'fatal';
-      if (errorMessage.includes('Parse error') || errorMessage.includes('Missing required field')) {
-        errorType = 'parse';
-      } else if (errorMessage.includes('Transform error')) {
-        errorType = 'transform';
-      } else if (errorMessage.includes('Failed to write') || errorMessage.includes('create directory')) {
-        errorType = 'write';
-      }
-
-      // Emit error event
-      const errorEvent: ConversionErrorEvent = {
-        type: errorType,
-        slug,
-        message: errorMessage,
-      };
-      this.emit('conversion-error', errorEvent);
-
-      return {
-        slug,
-        title: post.title || slug,
-        outputPath: '',
-        success: false,
-        error: errorMessage,
-      };
+    // Route to appropriate handler based on instance-level output mode
+    if (this.outputStructure.mode === 'flat') {
+      return this.convertPostFlat(post, slug, outputDir, options);
+    } else {
+      return this.convertPostNested(post, slug, outputDir, options);
     }
+  }
+
+  /**
+   * Parse post metadata and transform markdown content.
+   * First step in the conversion pipeline.
+   *
+   * @param post - The Hashnode post to process
+   * @returns Parsed metadata and transformed markdown
+   */
+  private parseAndTransform(post: HashnodePost): {
+    metadata: PostMetadata;
+    transformedMarkdown: string;
+  } {
+    const metadata = this.postParser.parse(post);
+    const transformedMarkdown = this.markdownTransformer.transform(metadata.contentMarkdown);
+    return { metadata, transformedMarkdown };
+  }
+
+  /**
+   * Create an ImageProcessor instance based on conversion options.
+   * When custom downloadOptions are provided, creates a new instance.
+   * Otherwise, uses the instance's default ImageProcessor.
+   *
+   * Note: Creating new instances is safe because download state is persisted
+   * via .downloaded-markers/ files on disk, not in-memory. Custom options
+   * only affect retry behavior for new/failed downloads.
+   *
+   * @param options - Conversion options that may include downloadOptions
+   * @returns ImageProcessor instance (new or default)
+   */
+  private createImageProcessor(options?: ConversionOptions): ImageProcessor {
+    return options?.downloadOptions
+      ? new ImageProcessor(options.downloadOptions)
+      : this.imageProcessor;
+  }
+
+  /**
+   * Ensure a directory exists, creating it if necessary.
+   * Creates parent directories recursively as needed.
+   *
+   * @param dir - Directory path to ensure exists
+   */
+  private ensureDirectoryExists(dir: string): void {
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+  }
+
+  /**
+   * Process image result metadata: emit events and track errors.
+   * This should be called after image processing completes.
+   *
+   * @param imageResult - Result from image processing
+   * @param slug - Post slug for event identification
+   */
+  private processImageResult(imageResult: ImageProcessingResult, slug: string): void {
+    this.emitImageDownloadedEvents(imageResult, slug);
+    this.trackHttp403Errors(imageResult.errors, slug);
+  }
+
+  /**
+   * Write the final markdown file with frontmatter and content.
+   * The FileWriter instance determines the output structure (flat vs nested).
+   *
+   * @param metadata - Post metadata for slug and title
+   * @param outputDir - Output directory
+   * @param imageResult - Processed markdown with localized images
+   * @returns Path to the written file
+   */
+  private async writeMarkdownFile(
+    metadata: PostMetadata,
+    outputDir: string,
+    imageResult: ImageProcessingResult
+  ): Promise<string> {
+    const frontmatter = this.frontmatterGenerator.generate(metadata);
+    return await this.fileWriter.writePost(
+      outputDir,
+      metadata.slug,
+      frontmatter,
+      imageResult.markdown
+    );
+  }
+
+  /**
+   * Create a successful conversion result.
+   *
+   * @param metadata - Post metadata
+   * @param outputPath - Path where the file was written
+   * @returns Success result object
+   */
+  private createSuccessResult(metadata: PostMetadata, outputPath: string): ConvertedPost {
+    return {
+      slug: metadata.slug,
+      title: metadata.title,
+      outputPath,
+      success: true,
+    };
+  }
+
+  /**
+   * Convert a single post using nested output mode.
+   * Creates {slug}/index.md with images in the same directory.
+   *
+   * @private
+   */
+  private async convertPostNested(
+    post: HashnodePost,
+    slug: string,
+    outputDir: string,
+    options?: ConversionOptions
+  ): Promise<ConvertedPost> {
+    try {
+      // Parse and transform content
+      const { metadata, transformedMarkdown } = this.parseAndTransform(post);
+
+      // Set up nested structure: outputDir/slug/
+      const imageDir = path.join(outputDir, metadata.slug);
+      this.ensureDirectoryExists(imageDir);
+
+      // Process images with nested structure
+      const imageProcessor = this.createImageProcessor(options);
+      const imageResult = await imageProcessor.process(transformedMarkdown, imageDir);
+
+      // Emit events and track errors
+      this.processImageResult(imageResult, metadata.slug);
+
+      // Write file and return success
+      const outputPath = await this.writeMarkdownFile(metadata, outputDir, imageResult);
+      return this.createSuccessResult(metadata, outputPath);
+    } catch (error) {
+      return this.handleConversionError(error, slug, post);
+    }
+  }
+
+  /**
+   * Validates that outputDir is properly nested for flat mode.
+   * Flat mode requires a nested structure (e.g., /blog/_posts) to create
+   * sibling directories (e.g., /blog/_images).
+   *
+   * @param outputDir - The output directory to validate
+   * @throws {Error} If outputDir is at root or single-level
+   * @private
+   */
+  private validateFlatModeOutputPath(outputDir: string): void {
+    const normalizedPath = path.resolve(outputDir);
+    const parentDir = path.dirname(normalizedPath);
+
+    // Check if parent is root (Unix '/' or Windows 'C:/')
+    const isAtRoot =
+      parentDir === '/' ||
+      /^[A-Z]:[/\\]?$/.test(parentDir) ||
+      parentDir === normalizedPath;
+
+    if (isAtRoot) {
+      throw new Error(
+        `Invalid outputDir for flat mode: "${outputDir}"\n` +
+          `Flat mode requires a nested directory structure (e.g., "blog/_posts") ` +
+          `to create sibling image directories (e.g., "blog/_images").\n` +
+          `Current path has no valid parent directory for sibling placement.\n` +
+          `Suggestions:\n` +
+          `  - Use: "./blog/_posts" or "/path/to/blog/_posts"\n` +
+          `  - Avoid: "/output" or "./posts" (single-level paths)`
+      );
+    }
+  }
+
+  /**
+   * Convert a single post using flat output mode.
+   * Creates {slug}.md with images in a shared sibling directory.
+   *
+   * @private
+   */
+  private async convertPostFlat(
+    post: HashnodePost,
+    slug: string,
+    outputDir: string,
+    options?: ConversionOptions
+  ): Promise<ConvertedPost> {
+    try {
+      // Validate flat mode requirements
+      this.validateFlatModeOutputPath(outputDir);
+
+      // Parse and transform content
+      const { metadata, transformedMarkdown } = this.parseAndTransform(post);
+
+      // Set up flat structure: sibling image directory
+      const parentDir = path.dirname(outputDir);
+      const imageFolderName = this.outputStructure.imageFolderName ?? '_images';
+      const imageDir = path.join(parentDir, imageFolderName);
+      const imagePathPrefix = this.outputStructure.imagePathPrefix ?? '/images';
+      this.ensureDirectoryExists(imageDir);
+
+      // Process images with flat structure and custom path prefix
+      const imageProcessor = this.createImageProcessor(options);
+      const imageResult = await imageProcessor.processWithContext(transformedMarkdown, {
+        imageDir,
+        imagePathPrefix,
+      });
+
+      // Emit events and track errors
+      this.processImageResult(imageResult, metadata.slug);
+
+      // Write file and return success
+      const outputPath = await this.writeMarkdownFile(metadata, outputDir, imageResult);
+      return this.createSuccessResult(metadata, outputPath);
+    } catch (error) {
+      return this.handleConversionError(error, slug, post);
+    }
+  }
+
+  /**
+   * Handle conversion errors consistently across both modes.
+   *
+   * @private
+   */
+  private handleConversionError(
+    error: unknown,
+    slug: string,
+    post: HashnodePost
+  ): ConvertedPost {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    // Determine error type based on error source
+    let errorType: ConversionErrorEvent['type'] = 'fatal';
+    if (errorMessage.includes('Parse error') || errorMessage.includes('Missing required field')) {
+      errorType = 'parse';
+    } else if (errorMessage.includes('Transform error')) {
+      errorType = 'transform';
+    } else if (
+      errorMessage.includes('Failed to write') ||
+      errorMessage.includes('create directory') ||
+      errorMessage.includes('Image directory does not exist') ||
+      errorMessage.includes('Invalid outputDir for flat mode')
+    ) {
+      errorType = 'write';
+    }
+
+    // Emit error event
+    const errorEvent: ConversionErrorEvent = {
+      type: errorType,
+      slug,
+      message: errorMessage,
+    };
+    this.emit('conversion-error', errorEvent);
+
+    return {
+      slug,
+      title: post.title || slug,
+      outputPath: '',
+      success: false,
+      error: errorMessage,
+    };
   }
 
   // ==================== Private Helper Methods ====================

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -11,6 +11,7 @@ import { Logger } from './services/logger.js';
 import { Post } from './models/post.js';
 
 import type { HashnodePost, HashnodeExport, PostMetadata } from './types/hashnode-schema.js';
+import { DEFAULT_IMAGE_FOLDER } from './types/converter-options.js';
 import type { ConversionOptions, OutputStructure, ConverterConfig } from './types/converter-options.js';
 import type { ConversionResult, ConvertedPost, ConversionError } from './types/conversion-result.js';
 import type {
@@ -626,7 +627,7 @@ export class Converter extends EventEmitter {
 
       // Set up flat structure: sibling image directory
       const parentDir = path.dirname(outputDir);
-      const imageFolderName = this.outputStructure.imageFolderName ?? '_images';
+      const imageFolderName = this.outputStructure.imageFolderName ?? DEFAULT_IMAGE_FOLDER;
       const imageDir = path.join(parentDir, imageFolderName);
       const imagePathPrefix = this.outputStructure.imagePathPrefix ?? '/images';
       this.ensureDirectoryExists(imageDir);

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,4 +71,5 @@ export type {
   ImageProcessorOptions,
   ImageProcessingResult,
   ImageProcessingError,
+  ImageProcessorContext,
 } from './types/image-processor.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,12 @@ export type {
 export { FileWriter, FileWriteError } from './services/file-writer.js';
 export type { FileWriterConfig } from './services/file-writer.js';
 
+// -----------------------------------------------------------------------------
+// Models
+// -----------------------------------------------------------------------------
+export { Post, PostValidationError } from './models/post.js';
+export type { PostConfig, OutputMode } from './models/post.js';
+
 export { Logger } from './services/logger.js';
 
 // -----------------------------------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,14 @@ export type { ConverterDependencies } from './converter.js';
 // Type Definitions
 // -----------------------------------------------------------------------------
 export * from './types/hashnode-schema.js';
-export * from './types/converter-options.js';
+export type {
+  ConversionOptions,
+  ConverterConfig,
+  ImageDownloadOptions,
+  LoggerConfig,
+  OutputStructure,
+} from './types/converter-options.js';
+export { DEFAULT_IMAGE_FOLDER } from './types/converter-options.js';
 export * from './types/conversion-result.js';
 export * from './types/converter-events.js';
 

--- a/src/models/post.ts
+++ b/src/models/post.ts
@@ -1,0 +1,169 @@
+import * as path from 'node:path';
+
+export type OutputMode = 'nested' | 'flat';
+
+export interface PostConfig {
+  slug: string;
+  frontmatter: string;
+  content: string;
+  outputMode?: OutputMode;
+}
+
+/**
+ * Custom error class for Post validation errors.
+ * Provides context about slug validation failures.
+ */
+export class PostValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly slug: string
+  ) {
+    super(message);
+    this.name = 'PostValidationError';
+  }
+}
+
+/**
+ * Represents a blog post with its content and path resolution logic.
+ * Encapsulates knowledge of how posts are organized on disk.
+ *
+ * The Post model handles:
+ * - Slug sanitization (filesystem safety)
+ * - Path resolution (mode-aware: nested vs flat)
+ * - Content combination (frontmatter + body)
+ *
+ * @example
+ * ```typescript
+ * const post = new Post({
+ *   slug: 'my-blog-post',
+ *   frontmatter: '---\ntitle: My Post\n---',
+ *   content: '# Hello World',
+ *   outputMode: 'flat',
+ * });
+ *
+ * post.getFilePath('./blog'); // './blog/my-blog-post.md'
+ * post.getMarkdown();         // '---\ntitle: My Post\n---\n# Hello World'
+ * ```
+ */
+export class Post {
+  readonly slug: string;
+  readonly frontmatter: string;
+  readonly content: string;
+  readonly outputMode: OutputMode;
+
+  constructor(config: PostConfig) {
+    this.slug = this.sanitizeSlug(config.slug);
+    this.frontmatter = config.frontmatter;
+    this.content = config.content;
+    this.outputMode = config.outputMode ?? 'nested';
+  }
+
+  /**
+   * Get the full file path for this post.
+   * @param outputDir - Base output directory
+   * @returns Full path to the markdown file
+   *
+   * @example
+   * // Nested mode (default)
+   * post.getFilePath('./blog'); // './blog/my-post/index.md'
+   *
+   * // Flat mode
+   * post.getFilePath('./blog'); // './blog/my-post.md'
+   */
+  getFilePath(outputDir: string): string {
+    if (this.outputMode === 'flat') {
+      return path.join(outputDir, `${this.slug}.md`);
+    }
+    return path.join(outputDir, this.slug, 'index.md');
+  }
+
+  /**
+   * Get the directory path that must exist before writing.
+   * @param outputDir - Base output directory
+   * @returns Directory path to ensure exists
+   *
+   * @example
+   * // Nested mode: needs post subdirectory
+   * post.getDirectoryPath('./blog'); // './blog/my-post'
+   *
+   * // Flat mode: only needs output directory
+   * post.getDirectoryPath('./blog'); // './blog'
+   */
+  getDirectoryPath(outputDir: string): string {
+    if (this.outputMode === 'flat') {
+      return outputDir;
+    }
+    return path.join(outputDir, this.slug);
+  }
+
+  /**
+   * Get the combined markdown content (frontmatter + content).
+   * @returns Full markdown string ready to write to file
+   */
+  getMarkdown(): string {
+    return this.frontmatter + '\n' + this.content;
+  }
+
+  /**
+   * Get the path to check for post existence.
+   * In nested mode, checks for directory.
+   * In flat mode, checks for file.
+   * @param outputDir - Base output directory
+   * @returns Path to check for existence
+   */
+  getExistencePath(outputDir: string): string {
+    if (this.outputMode === 'flat') {
+      return path.join(outputDir, `${this.slug}.md`);
+    }
+    return path.join(outputDir, this.slug);
+  }
+
+  /**
+   * Sanitize a slug for filesystem safety.
+   * @throws PostValidationError if slug is invalid
+   */
+  private sanitizeSlug(slug: string): string {
+    const trimmed = slug.trim();
+
+    this.rejectAbsolutePath(trimmed, slug);
+    this.rejectDirectoryTraversal(trimmed, slug);
+
+    // Replace invalid filename characters with hyphens
+    const sanitized = trimmed.replace(/[/\\:*?"<>|]/g, '-');
+
+    if (sanitized.length === 0) {
+      throw new PostValidationError(
+        `Invalid slug: slug is empty after sanitization (original: ${slug})`,
+        slug
+      );
+    }
+
+    return sanitized;
+  }
+
+  /**
+   * Reject slugs that are absolute paths.
+   * @throws PostValidationError if slug starts with '/'
+   */
+  private rejectAbsolutePath(sanitized: string, original: string): void {
+    if (sanitized.startsWith('/')) {
+      throw new PostValidationError(
+        `Invalid slug: absolute paths are not allowed (${original})`,
+        original
+      );
+    }
+  }
+
+  /**
+   * Reject slugs containing parent directory traversal.
+   * @throws PostValidationError if slug contains '..'
+   */
+  private rejectDirectoryTraversal(sanitized: string, original: string): void {
+    if (sanitized.includes('..')) {
+      throw new PostValidationError(
+        `Invalid slug: parent directory traversal is not allowed (${original})`,
+        original
+      );
+    }
+  }
+}

--- a/src/processors/image-processor.ts
+++ b/src/processors/image-processor.ts
@@ -27,6 +27,20 @@ import type {
  *   - Transient failure: `.marker` file with error message (will retry)
  *   - Permanent failure (403): `.marker.403` file (won't retry)
  *
+ * Instance Independence:
+ * Because download state is persisted to disk via marker files
+ * (not in-memory), multiple ImageProcessor instances can reuse
+ * the same on-disk state when pointing at the same blog/image
+ * directories. Creating a new instance with different options
+ * won't cause re-downloading of already-downloaded images. This
+ * design enables:
+ * - Safe per-conversion custom options (different retry settings)
+ * - Resumable downloads across process restarts
+ * - Reduced redundant downloads when reusing the same marker directory
+ * - Shared image deduplication in flat mode (when using a flat layout)
+ *
+ * @see {@link Converter.createImageProcessor} for usage in flat mode implementation
+ *
  * @example
  * ```typescript
  * const processor = new ImageProcessor({

--- a/src/processors/image-processor.ts
+++ b/src/processors/image-processor.ts
@@ -54,6 +54,15 @@ export class ImageProcessor {
    * Create a new ImageProcessor instance.
    *
    * @param options - Configuration options for image downloading
+   *
+   * TODO: Add optional `downloader` parameter for dependency injection to improve testability.
+   * Current limitation: ImageDownloader is created internally, preventing reliable mocking
+   * in integration tests. Proposed signature:
+   * ```typescript
+   * constructor(options?: ImageProcessorOptions, downloader?: ImageDownloader)
+   * ```
+   * This would enable proper mocking without conditional assertions in tests.
+   * @see https://github.com/alvincrespo/hashnode-content-converter/issues/87
    */
   constructor(options?: ImageProcessorOptions) {
     // Set defaults matching reference implementation
@@ -65,6 +74,7 @@ export class ImageProcessor {
     };
 
     // Create ImageDownloader with configuration
+    // TODO: Make this injectable via optional constructor parameter (Issue #87)
     this.downloader = new ImageDownloader({
       maxRetries: this.options.maxRetries,
       retryDelayMs: this.options.retryDelayMs,

--- a/src/services/file-writer.ts
+++ b/src/services/file-writer.ts
@@ -192,16 +192,24 @@ export class FileWriter {
   }
 
   /**
-   * Check if a post already exists in the output directory
+   * Check if a post already exists in the output directory.
+   * In nested mode, checks for directory existence.
+   * In flat mode, checks for {slug}.md file existence.
    * @param outputDir - Base output directory
    * @param slug - Post slug to check
-   * @returns True if post directory exists, false otherwise
+   * @returns True if post exists, false otherwise (including on errors)
    */
   postExists(outputDir: string, slug: string): boolean {
     try {
-      const sanitized = this.sanitizeSlug(slug);
-      const postDir = path.join(outputDir, sanitized);
-      return fs.existsSync(postDir);
+      let sanitized = this.sanitizeSlug(slug);
+
+      // Flat mode: check for {slug}.md file
+      if (this.config.outputMode === 'flat') {
+        sanitized = `${sanitized}.md`;
+      }
+
+      const postPath = path.join(outputDir, sanitized);
+      return fs.existsSync(postPath);
     } catch {
       // If sanitization fails, the post doesn't exist (invalid slug)
       return false;

--- a/src/types/converter-options.ts
+++ b/src/types/converter-options.ts
@@ -75,6 +75,19 @@ export interface OutputStructure {
 }
 
 /**
+ * Instance-level configuration for Converter.
+ * These settings apply to all conversions performed by this instance.
+ */
+export interface ConverterConfig {
+  /**
+   * Output structure configuration.
+   * Controls file naming and image storage location.
+   * @default { mode: 'nested' }
+   */
+  outputStructure?: OutputStructure;
+}
+
+/**
  * Configuration options for the conversion process
  */
 export interface ConversionOptions {
@@ -95,11 +108,4 @@ export interface ConversionOptions {
    * Logger configuration options.
    */
   loggerConfig?: LoggerConfig;
-
-  /**
-   * Output structure configuration.
-   * Controls file naming and image storage location.
-   * @default { mode: 'nested' }
-   */
-  outputStructure?: OutputStructure;
 }

--- a/src/types/converter-options.ts
+++ b/src/types/converter-options.ts
@@ -45,6 +45,36 @@ export interface LoggerConfig {
 }
 
 /**
+ * Output structure configuration for the conversion process.
+ * Controls how posts and images are organized on disk.
+ */
+export interface OutputStructure {
+  /**
+   * Output mode determines file organization:
+   * - 'nested': Creates {slug}/index.md with images in same directory (default)
+   * - 'flat': Creates {slug}.md with images in shared sibling directory
+   * @default 'nested'
+   */
+  mode: 'nested' | 'flat';
+
+  /**
+   * Name of the shared image folder (flat mode only).
+   * Created as a sibling to the output directory.
+   * @default '_images'
+   * @example 'assets' -> creates {output}/../assets/
+   */
+  imageFolderName?: string;
+
+  /**
+   * Path prefix for image references in markdown (flat mode only).
+   * Should match your static site generator's asset path configuration.
+   * @default '/images'
+   * @example '/assets/images' -> ![alt](/assets/images/filename.png)
+   */
+  imagePathPrefix?: string;
+}
+
+/**
  * Configuration options for the conversion process
  */
 export interface ConversionOptions {
@@ -65,4 +95,11 @@ export interface ConversionOptions {
    * Logger configuration options.
    */
   loggerConfig?: LoggerConfig;
+
+  /**
+   * Output structure configuration.
+   * Controls file naming and image storage location.
+   * @default { mode: 'nested' }
+   */
+  outputStructure?: OutputStructure;
 }

--- a/src/types/converter-options.ts
+++ b/src/types/converter-options.ts
@@ -45,6 +45,12 @@ export interface LoggerConfig {
 }
 
 /**
+ * Default name for the shared image folder in flat output mode.
+ * Used when `OutputStructure.imageFolderName` is not specified.
+ */
+export const DEFAULT_IMAGE_FOLDER = '_images';
+
+/**
  * Output structure configuration for the conversion process.
  * Controls how posts and images are organized on disk.
  */

--- a/src/types/image-processor.ts
+++ b/src/types/image-processor.ts
@@ -92,3 +92,29 @@ export interface ImageProcessingError {
    */
   is403: boolean;
 }
+
+/**
+ * Context for image processing that includes output structure information.
+ * Used by ImageProcessor.processWithContext() for flat mode support.
+ */
+export interface ImageProcessorContext {
+  /**
+   * Directory where images should be saved.
+   * In nested mode: {output}/{slug}/
+   * In flat mode: {output}/../_images/
+   */
+  imageDir: string;
+
+  /**
+   * Path prefix for image references in markdown.
+   * In nested mode: '.'
+   * In flat mode: '/images' (or custom prefix)
+   */
+  imagePathPrefix: string;
+
+  /**
+   * Optional custom directory for download markers.
+   * Defaults to {imageDir}/.downloaded-markers/
+   */
+  markerDir?: string;
+}

--- a/tests/integration/converter-flat-mode.integration.test.ts
+++ b/tests/integration/converter-flat-mode.integration.test.ts
@@ -1,0 +1,392 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { Converter } from '../../src/converter.js';
+import type { HashnodePost } from '../../src/types/hashnode-schema.js';
+
+// ============================================================================
+// INTEGRATION TESTS WITH REAL FILE I/O
+// ============================================================================
+// This file does NOT mock fs - all filesystem operations are real.
+// Tests verify the complete end-to-end conversion pipeline for flat output mode.
+//
+// Note: These tests focus on file structure and directory creation validation.
+// Image downloads use real network calls (may fail in CI), so assertions focus
+// on directory structure rather than downloaded file content.
+// ============================================================================
+
+/**
+ * Create a test fixture for HashnodePost with sensible defaults.
+ * This reduces duplication and improves type safety across tests.
+ *
+ * @param overrides - Partial HashnodePost object to override defaults
+ * @returns Complete HashnodePost object for testing
+ */
+function createTestPost(overrides: Partial<HashnodePost> = {}): HashnodePost {
+  return {
+    _id: 'test001',
+    id: 'test001',
+    cuid: 'test001',
+    slug: 'test-post',
+    title: 'Test Post',
+    contentMarkdown: '# Test Content',
+    content: '<h1>Test Content</h1>',
+    dateAdded: '2024-01-15T10:00:00.000Z',
+    createdAt: '2024-01-15T10:00:00.000Z',
+    updatedAt: '2024-01-15T10:00:00.000Z',
+    brief: 'Test brief',
+    views: 0,
+    author: 'Test Author',
+    tags: [],
+    isActive: true,
+    ...overrides,
+  };
+}
+
+describe('Converter - Flat Output Mode Integration Tests', () => {
+  let tempDir: string;
+  let exportPath: string;
+  let outputDir: string;
+
+  beforeEach(() => {
+    // Create unique temp directory for isolation
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hashnode-flat-test-'));
+
+    // Setup nested output structure (required for flat mode validation)
+    outputDir = path.join(tempDir, 'blog', '_posts');
+    fs.mkdirSync(outputDir, { recursive: true });
+
+    // Export path (will be created per-test with specific data)
+    exportPath = path.join(tempDir, 'export.json');
+  });
+
+  afterEach(() => {
+    // Cleanup temp directory (force: true ensures cleanup even on test failure)
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should write posts as {slug}.md in flat mode', async () => {
+    // Arrange - Create Converter with flat mode config
+    const flatConverter = new Converter({
+      config: {
+        outputStructure: { mode: 'flat' },
+      },
+    });
+
+    const exportData = {
+      posts: [
+        createTestPost({
+          _id: 'test001',
+          slug: 'test-post-1',
+          title: 'Test Post 1',
+          contentMarkdown: '# Heading\n\nContent here.',
+          content: '<h1>Heading</h1><p>Content here.</p>',
+          brief: 'Test brief',
+          dateAdded: '2024-01-15T10:00:00.000Z',
+        }),
+        createTestPost({
+          _id: 'test002',
+          slug: 'test-post-2',
+          title: 'Test Post 2',
+          contentMarkdown: '# Another Post',
+          content: '<h1>Another Post</h1>',
+          brief: 'Another brief',
+          dateAdded: '2024-01-16T10:00:00.000Z',
+        }),
+      ],
+    };
+    fs.writeFileSync(exportPath, JSON.stringify(exportData));
+
+    // Act
+    const result = await flatConverter.convertAllPosts(exportPath, outputDir, {
+      skipExisting: false,
+    });
+
+    // Assert - Result stats
+    expect(result.converted).toBe(2);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toHaveLength(0);
+
+    // Assert - File structure (flat mode)
+    expect(fs.existsSync(path.join(outputDir, 'test-post-1.md'))).toBe(true);
+    expect(fs.existsSync(path.join(outputDir, 'test-post-2.md'))).toBe(true);
+
+    // Assert - No nested directories created
+    expect(fs.existsSync(path.join(outputDir, 'test-post-1'))).toBe(false);
+    expect(fs.existsSync(path.join(outputDir, 'test-post-2'))).toBe(false);
+
+    // Assert - Content format
+    const content1 = fs.readFileSync(path.join(outputDir, 'test-post-1.md'), 'utf8');
+    expect(content1).toMatch(/^---\n/); // Frontmatter start
+    expect(content1).toContain('title:'); // Has title field
+    expect(content1).toContain('Test Post 1'); // Title value present
+    expect(content1).toContain('# Heading'); // Markdown content present
+  });
+
+  it('should place images in sibling _images folder', async () => {
+    // Arrange - Create Converter with flat mode config
+    const flatConverter = new Converter({
+      config: {
+        outputStructure: { mode: 'flat' },
+      },
+    });
+
+    const exportData = {
+      posts: [
+        createTestPost({
+          slug: 'post-with-image',
+          title: 'Post With Image',
+          contentMarkdown: '![alt text](https://cdn.hashnode.com/res/hashnode/image/upload/v123/test-image-abc123.png)',
+          content: '<p><img src="https://cdn.hashnode.com/res/hashnode/image/upload/v123/test-image-abc123.png" alt="alt text"></p>',
+          brief: 'Test post with image',
+        }),
+      ],
+    };
+    fs.writeFileSync(exportPath, JSON.stringify(exportData));
+
+    // Act
+    await flatConverter.convertAllPosts(exportPath, outputDir, {
+      skipExisting: false,
+    });
+
+    // Assert - Image directory structure exists (even if download fails)
+    const imageDir = path.join(outputDir, '..', '_images');
+    expect(fs.existsSync(imageDir)).toBe(true);
+
+    // Assert - Markers directory exists (created on any image processing attempt)
+    const markersDir = path.join(imageDir, '.downloaded-markers');
+    expect(fs.existsSync(markersDir)).toBe(true);
+
+    // Assert - No post directory created (flat mode)
+    const postDir = path.join(outputDir, 'post-with-image');
+    expect(fs.existsSync(postDir)).toBe(false);
+
+    // Assert - Post file created
+    expect(fs.existsSync(path.join(outputDir, 'post-with-image.md'))).toBe(true);
+  });
+
+  it('should use /images prefix in markdown references', async () => {
+    // Arrange - Create Converter with flat mode config
+    const flatConverter = new Converter({
+      config: {
+        outputStructure: { mode: 'flat' },
+      },
+    });
+
+    const exportData = {
+      posts: [
+        createTestPost({
+          slug: 'image-post',
+          title: 'Image Post',
+          contentMarkdown: 'Text before ![alt text](https://cdn.hashnode.com/res/hashnode/image/upload/v1/xyz-789.jpg) text after',
+          content: '<p>Text before <img src="https://cdn.hashnode.com/res/hashnode/image/upload/v1/xyz-789.jpg" alt="alt text"> text after</p>',
+        }),
+      ],
+    };
+    fs.writeFileSync(exportPath, JSON.stringify(exportData));
+
+    // Act
+    await flatConverter.convertAllPosts(exportPath, outputDir, {
+      skipExisting: false,
+    });
+
+    // Assert - Read markdown content
+    const content = fs.readFileSync(path.join(outputDir, 'image-post.md'), 'utf8');
+
+    // Assert - Verify flat mode does NOT use relative paths
+    // In flat mode, images should use absolute prefix (if downloaded successfully)
+    // or keep CDN URL (if download failed) - but never relative ./paths
+    expect(content).not.toContain('![alt text](./xyz-789.jpg)');
+
+    // Assert - File was created successfully
+    expect(content).toContain('Text before');
+    expect(content).toContain('text after');
+  });
+
+  it('should skip existing {slug}.md files when skipExisting is true', async () => {
+    // Arrange - Create Converter with flat mode config
+    const flatConverter = new Converter({
+      config: {
+        outputStructure: { mode: 'flat' },
+      },
+    });
+
+    const exportData = {
+      posts: [
+        createTestPost({
+          _id: 'test001',
+          slug: 'existing-post',
+          title: 'Existing Post',
+          contentMarkdown: '# New Content\n\nThis should not be written.',
+          content: '<h1>New Content</h1>',
+        }),
+        createTestPost({
+          _id: 'test002',
+          slug: 'new-post',
+          title: 'New Post',
+          contentMarkdown: '# Fresh Content\n\nThis should be written.',
+          content: '<h1>Fresh Content</h1>',
+        }),
+      ],
+    };
+    fs.writeFileSync(exportPath, JSON.stringify(exportData));
+
+    // Pre-create existing post file
+    const existingContent = '---\ntitle: "Old Version"\n---\n\n# Old Content';
+    fs.writeFileSync(path.join(outputDir, 'existing-post.md'), existingContent);
+
+    // Act
+    const result = await flatConverter.convertAllPosts(exportPath, outputDir, {
+      skipExisting: true,
+    });
+
+    // Assert - Stats
+    expect(result.converted).toBe(1); // Only new-post
+    expect(result.skipped).toBe(1); // existing-post
+
+    // Assert - Existing file unchanged
+    const existingFileContent = fs.readFileSync(
+      path.join(outputDir, 'existing-post.md'),
+      'utf8'
+    );
+    expect(existingFileContent).toBe(existingContent);
+    expect(existingFileContent).toContain('Old Version');
+    expect(existingFileContent).not.toContain('New Content');
+
+    // Assert - New file created
+    expect(fs.existsSync(path.join(outputDir, 'new-post.md'))).toBe(true);
+    const newFileContent = fs.readFileSync(path.join(outputDir, 'new-post.md'), 'utf8');
+    expect(newFileContent).toContain('Fresh Content');
+  });
+
+  it('should respect custom imageFolderName', async () => {
+    // Arrange - Create Converter with flat mode and custom image folder name
+    const flatConverter = new Converter({
+      config: {
+        outputStructure: {
+          mode: 'flat',
+          imageFolderName: 'assets', // Custom folder name
+        },
+      },
+    });
+
+    const exportData = {
+      posts: [
+        createTestPost({
+          slug: 'custom-folder-post',
+          title: 'Custom Folder Post',
+          contentMarkdown: '![img](https://cdn.hashnode.com/res/hashnode/image/upload/v1/custom-123.png)',
+          content: '<p><img src="https://cdn.hashnode.com/res/hashnode/image/upload/v1/custom-123.png" alt="img"></p>',
+        }),
+      ],
+    };
+    fs.writeFileSync(exportPath, JSON.stringify(exportData));
+
+    // Act
+    await flatConverter.convertAllPosts(exportPath, outputDir, {
+      skipExisting: false,
+    });
+
+    // Assert - Custom image directory exists
+    const customImageDir = path.join(outputDir, '..', 'assets');
+    expect(fs.existsSync(customImageDir)).toBe(true);
+
+    // Assert - Default _images directory NOT created
+    const defaultImageDir = path.join(outputDir, '..', '_images');
+    expect(fs.existsSync(defaultImageDir)).toBe(false);
+
+    // Assert - Markers directory created in custom location
+    const markersDir = path.join(customImageDir, '.downloaded-markers');
+    expect(fs.existsSync(markersDir)).toBe(true);
+
+    // Assert - Post file created
+    expect(fs.existsSync(path.join(outputDir, 'custom-folder-post.md'))).toBe(true);
+  });
+
+  it('should respect custom imagePathPrefix', async () => {
+    // Arrange - Create Converter with flat mode and custom image path prefix
+    const flatConverter = new Converter({
+      config: {
+        outputStructure: {
+          mode: 'flat',
+          imagePathPrefix: '/static/images', // Custom path prefix
+        },
+      },
+    });
+
+    const exportData = {
+      posts: [
+        createTestPost({
+          slug: 'custom-prefix-post',
+          title: 'Custom Prefix Post',
+          contentMarkdown: '![img](https://cdn.hashnode.com/res/hashnode/image/upload/v1/prefix-456.jpg)',
+          content: '<p><img src="https://cdn.hashnode.com/res/hashnode/image/upload/v1/prefix-456.jpg" alt="img"></p>',
+        }),
+      ],
+    };
+    fs.writeFileSync(exportPath, JSON.stringify(exportData));
+
+    // Act
+    await flatConverter.convertAllPosts(exportPath, outputDir, {
+      skipExisting: false,
+    });
+
+    // Assert - Post file created
+    expect(fs.existsSync(path.join(outputDir, 'custom-prefix-post.md'))).toBe(true);
+
+    // Assert - Read markdown content
+    const content = fs.readFileSync(
+      path.join(outputDir, 'custom-prefix-post.md'),
+      'utf8'
+    );
+
+    // Assert - Verify NOT using relative path (flat mode should use absolute prefix)
+    expect(content).not.toContain('![img](./prefix-456.jpg)');
+
+    // Assert - Custom image directory created
+    const imageDir = path.join(outputDir, '..', '_images');
+    expect(fs.existsSync(imageDir)).toBe(true);
+  });
+
+  it('should maintain backwards compatibility in nested mode', async () => {
+    // Arrange - Create Converter with NO config (defaults to nested mode)
+    const nestedConverter = new Converter();
+
+    const exportData = {
+      posts: [
+        createTestPost({
+          slug: 'nested-post',
+          title: 'Nested Post',
+          contentMarkdown: '![img](https://cdn.hashnode.com/res/hashnode/image/upload/v1/nested-789.png)',
+          content: '<p><img src="https://cdn.hashnode.com/res/hashnode/image/upload/v1/nested-789.png" alt="img"></p>',
+        }),
+      ],
+    };
+    fs.writeFileSync(exportPath, JSON.stringify(exportData));
+
+    // Act - No outputStructure option (defaults to nested)
+    await nestedConverter.convertAllPosts(exportPath, outputDir, {
+      skipExisting: false,
+    });
+
+    // Assert - Nested directory structure
+    const postDir = path.join(outputDir, 'nested-post');
+    expect(fs.existsSync(postDir)).toBe(true);
+    expect(fs.existsSync(path.join(postDir, 'index.md'))).toBe(true);
+
+    // Assert - No flat file created
+    expect(fs.existsSync(path.join(outputDir, 'nested-post.md'))).toBe(false);
+
+    // Assert - Content should have frontmatter
+    const content = fs.readFileSync(path.join(postDir, 'index.md'), 'utf8');
+    expect(content).toMatch(/^---\n/);
+    expect(content).toContain('title:');
+    expect(content).toContain('Nested Post');
+
+    // Assert - Not using absolute /images/ prefix (that's flat mode only)
+    expect(content).not.toContain('/images/nested-789');
+  });
+});

--- a/tests/integration/converter-flat-mode.integration.test.ts
+++ b/tests/integration/converter-flat-mode.integration.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { Converter } from '../../src/converter.js';
+import { ImageDownloader } from '../../src/services/image-downloader.js';
 import type { HashnodePost } from '../../src/types/hashnode-schema.js';
 
 // ============================================================================
@@ -11,9 +12,9 @@ import type { HashnodePost } from '../../src/types/hashnode-schema.js';
 // This file does NOT mock fs - all filesystem operations are real.
 // Tests verify the complete end-to-end conversion pipeline for flat output mode.
 //
-// Note: These tests focus on file structure and directory creation validation.
-// Image downloads use real network calls (may fail in CI), so assertions focus
-// on directory structure rather than downloaded file content.
+// ImageDownloader.download is mocked at the network boundary to avoid real
+// HTTPS calls. All other pipeline behavior (directory creation, marker files,
+// path rewriting, file writing) uses real code paths.
 // ============================================================================
 
 /**
@@ -59,9 +60,24 @@ describe('Converter - Flat Output Mode Integration Tests', () => {
 
     // Export path (will be created per-test with specific data)
     exportPath = path.join(tempDir, 'export.json');
+
+    // Mock network layer to avoid real HTTPS downloads while keeping
+    // all other pipeline behavior (directory creation, markers, path rewriting) real
+    vi.spyOn(ImageDownloader.prototype, 'download').mockImplementation(
+      async (_url: string, filepath: string) => {
+        const dir = path.dirname(filepath);
+        if (!fs.existsSync(dir)) {
+          fs.mkdirSync(dir, { recursive: true });
+        }
+        fs.writeFileSync(filepath, Buffer.from('fake-image-data'));
+        return { success: true };
+      }
+    );
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
+
     // Cleanup temp directory (force: true ensures cleanup even on test failure)
     if (fs.existsSync(tempDir)) {
       fs.rmSync(tempDir, { recursive: true, force: true });
@@ -139,8 +155,8 @@ describe('Converter - Flat Output Mode Integration Tests', () => {
         createTestPost({
           slug: 'post-with-image',
           title: 'Post With Image',
-          contentMarkdown: '![alt text](https://cdn.hashnode.com/res/hashnode/image/upload/v123/test-image-abc123.png)',
-          content: '<p><img src="https://cdn.hashnode.com/res/hashnode/image/upload/v123/test-image-abc123.png" alt="alt text"></p>',
+          contentMarkdown: '![alt text](https://cdn.hashnode.com/res/hashnode/image/upload/v123/550e8400-e29b-41d4-a716-446655440000.png)',
+          content: '<p><img src="https://cdn.hashnode.com/res/hashnode/image/upload/v123/550e8400-e29b-41d4-a716-446655440000.png" alt="alt text"></p>',
           brief: 'Test post with image',
         }),
       ],
@@ -152,20 +168,28 @@ describe('Converter - Flat Output Mode Integration Tests', () => {
       skipExisting: false,
     });
 
-    // Assert - Image directory structure exists (even if download fails)
+    // Assert - Image directory structure
     const imageDir = path.join(outputDir, '..', '_images');
     expect(fs.existsSync(imageDir)).toBe(true);
 
-    // Assert - Markers directory exists (created on any image processing attempt)
+    // Assert - Image file was downloaded
+    const imageFile = path.join(imageDir, '550e8400-e29b-41d4-a716-446655440000.png');
+    expect(fs.existsSync(imageFile)).toBe(true);
+
+    // Assert - Marker file created for successful download
     const markersDir = path.join(imageDir, '.downloaded-markers');
     expect(fs.existsSync(markersDir)).toBe(true);
+    expect(fs.existsSync(path.join(markersDir, '550e8400-e29b-41d4-a716-446655440000.png.marker'))).toBe(true);
 
     // Assert - No post directory created (flat mode)
     const postDir = path.join(outputDir, 'post-with-image');
     expect(fs.existsSync(postDir)).toBe(false);
 
-    // Assert - Post file created
-    expect(fs.existsSync(path.join(outputDir, 'post-with-image.md'))).toBe(true);
+    // Assert - Post file created with rewritten image path
+    const postFile = path.join(outputDir, 'post-with-image.md');
+    expect(fs.existsSync(postFile)).toBe(true);
+    const content = fs.readFileSync(postFile, 'utf8');
+    expect(content).toContain('![alt text](/images/550e8400-e29b-41d4-a716-446655440000.png)');
   });
 
   it('should use /images prefix in markdown references', async () => {
@@ -181,8 +205,8 @@ describe('Converter - Flat Output Mode Integration Tests', () => {
         createTestPost({
           slug: 'image-post',
           title: 'Image Post',
-          contentMarkdown: 'Text before ![alt text](https://cdn.hashnode.com/res/hashnode/image/upload/v1/xyz-789.jpg) text after',
-          content: '<p>Text before <img src="https://cdn.hashnode.com/res/hashnode/image/upload/v1/xyz-789.jpg" alt="alt text"> text after</p>',
+          contentMarkdown: 'Text before ![alt text](https://cdn.hashnode.com/res/hashnode/image/upload/v1/660e8400-e29b-41d4-a716-446655440001.jpg) text after',
+          content: '<p>Text before <img src="https://cdn.hashnode.com/res/hashnode/image/upload/v1/660e8400-e29b-41d4-a716-446655440001.jpg" alt="alt text"> text after</p>',
         }),
       ],
     };
@@ -196,12 +220,13 @@ describe('Converter - Flat Output Mode Integration Tests', () => {
     // Assert - Read markdown content
     const content = fs.readFileSync(path.join(outputDir, 'image-post.md'), 'utf8');
 
-    // Assert - Verify flat mode does NOT use relative paths
-    // In flat mode, images should use absolute prefix (if downloaded successfully)
-    // or keep CDN URL (if download failed) - but never relative ./paths
-    expect(content).not.toContain('![alt text](./xyz-789.jpg)');
+    // Assert - Flat mode rewrites image URLs with /images/ prefix
+    expect(content).toContain('![alt text](/images/660e8400-e29b-41d4-a716-446655440001.jpg)');
 
-    // Assert - File was created successfully
+    // Assert - Does NOT use relative paths (that's nested mode)
+    expect(content).not.toContain('![alt text](./660e8400-e29b-41d4-a716-446655440001.jpg)');
+
+    // Assert - Surrounding text preserved
     expect(content).toContain('Text before');
     expect(content).toContain('text after');
   });
@@ -278,8 +303,8 @@ describe('Converter - Flat Output Mode Integration Tests', () => {
         createTestPost({
           slug: 'custom-folder-post',
           title: 'Custom Folder Post',
-          contentMarkdown: '![img](https://cdn.hashnode.com/res/hashnode/image/upload/v1/custom-123.png)',
-          content: '<p><img src="https://cdn.hashnode.com/res/hashnode/image/upload/v1/custom-123.png" alt="img"></p>',
+          contentMarkdown: '![img](https://cdn.hashnode.com/res/hashnode/image/upload/v1/770e8400-e29b-41d4-a716-446655440002.png)',
+          content: '<p><img src="https://cdn.hashnode.com/res/hashnode/image/upload/v1/770e8400-e29b-41d4-a716-446655440002.png" alt="img"></p>',
         }),
       ],
     };
@@ -290,9 +315,10 @@ describe('Converter - Flat Output Mode Integration Tests', () => {
       skipExisting: false,
     });
 
-    // Assert - Custom image directory exists
+    // Assert - Custom image directory exists with downloaded image
     const customImageDir = path.join(outputDir, '..', 'assets');
     expect(fs.existsSync(customImageDir)).toBe(true);
+    expect(fs.existsSync(path.join(customImageDir, '770e8400-e29b-41d4-a716-446655440002.png'))).toBe(true);
 
     // Assert - Default _images directory NOT created
     const defaultImageDir = path.join(outputDir, '..', '_images');
@@ -301,6 +327,7 @@ describe('Converter - Flat Output Mode Integration Tests', () => {
     // Assert - Markers directory created in custom location
     const markersDir = path.join(customImageDir, '.downloaded-markers');
     expect(fs.existsSync(markersDir)).toBe(true);
+    expect(fs.existsSync(path.join(markersDir, '770e8400-e29b-41d4-a716-446655440002.png.marker'))).toBe(true);
 
     // Assert - Post file created
     expect(fs.existsSync(path.join(outputDir, 'custom-folder-post.md'))).toBe(true);
@@ -322,8 +349,8 @@ describe('Converter - Flat Output Mode Integration Tests', () => {
         createTestPost({
           slug: 'custom-prefix-post',
           title: 'Custom Prefix Post',
-          contentMarkdown: '![img](https://cdn.hashnode.com/res/hashnode/image/upload/v1/prefix-456.jpg)',
-          content: '<p><img src="https://cdn.hashnode.com/res/hashnode/image/upload/v1/prefix-456.jpg" alt="img"></p>',
+          contentMarkdown: '![img](https://cdn.hashnode.com/res/hashnode/image/upload/v1/880e8400-e29b-41d4-a716-446655440003.jpg)',
+          content: '<p><img src="https://cdn.hashnode.com/res/hashnode/image/upload/v1/880e8400-e29b-41d4-a716-446655440003.jpg" alt="img"></p>',
         }),
       ],
     };
@@ -343,12 +370,16 @@ describe('Converter - Flat Output Mode Integration Tests', () => {
       'utf8'
     );
 
-    // Assert - Verify NOT using relative path (flat mode should use absolute prefix)
-    expect(content).not.toContain('![img](./prefix-456.jpg)');
+    // Assert - Custom prefix used in markdown image references
+    expect(content).toContain('![img](/static/images/880e8400-e29b-41d4-a716-446655440003.jpg)');
 
-    // Assert - Custom image directory created
+    // Assert - Not using relative path (that's nested mode)
+    expect(content).not.toContain('![img](./880e8400-e29b-41d4-a716-446655440003.jpg)');
+
+    // Assert - Image file downloaded to _images directory
     const imageDir = path.join(outputDir, '..', '_images');
     expect(fs.existsSync(imageDir)).toBe(true);
+    expect(fs.existsSync(path.join(imageDir, '880e8400-e29b-41d4-a716-446655440003.jpg'))).toBe(true);
   });
 
   it('should maintain backwards compatibility in nested mode', async () => {
@@ -360,8 +391,8 @@ describe('Converter - Flat Output Mode Integration Tests', () => {
         createTestPost({
           slug: 'nested-post',
           title: 'Nested Post',
-          contentMarkdown: '![img](https://cdn.hashnode.com/res/hashnode/image/upload/v1/nested-789.png)',
-          content: '<p><img src="https://cdn.hashnode.com/res/hashnode/image/upload/v1/nested-789.png" alt="img"></p>',
+          contentMarkdown: '![img](https://cdn.hashnode.com/res/hashnode/image/upload/v1/990e8400-e29b-41d4-a716-446655440004.png)',
+          content: '<p><img src="https://cdn.hashnode.com/res/hashnode/image/upload/v1/990e8400-e29b-41d4-a716-446655440004.png" alt="img"></p>',
         }),
       ],
     };
@@ -377,6 +408,9 @@ describe('Converter - Flat Output Mode Integration Tests', () => {
     expect(fs.existsSync(postDir)).toBe(true);
     expect(fs.existsSync(path.join(postDir, 'index.md'))).toBe(true);
 
+    // Assert - Image downloaded into post directory (nested mode)
+    expect(fs.existsSync(path.join(postDir, '990e8400-e29b-41d4-a716-446655440004.png'))).toBe(true);
+
     // Assert - No flat file created
     expect(fs.existsSync(path.join(outputDir, 'nested-post.md'))).toBe(false);
 
@@ -386,7 +420,8 @@ describe('Converter - Flat Output Mode Integration Tests', () => {
     expect(content).toContain('title:');
     expect(content).toContain('Nested Post');
 
-    // Assert - Not using absolute /images/ prefix (that's flat mode only)
-    expect(content).not.toContain('/images/nested-789');
+    // Assert - Uses relative path (nested mode), not absolute /images/ prefix
+    expect(content).toContain('![img](./990e8400-e29b-41d4-a716-446655440004.png)');
+    expect(content).not.toContain('/images/990e8400-e29b-41d4-a716-446655440004');
   });
 });

--- a/tests/integration/converter.test.ts
+++ b/tests/integration/converter.test.ts
@@ -85,6 +85,13 @@ describe('Converter', () => {
         imagesSkipped: 0,
         errors: [],
       }),
+      processWithContext: vi.fn().mockResolvedValue({
+        markdown: '# Test Content',
+        imagesProcessed: 0,
+        imagesDownloaded: 0,
+        imagesSkipped: 0,
+        errors: [],
+      }),
     } as unknown as ImageProcessor;
 
     mockFrontmatterGenerator = {
@@ -710,6 +717,258 @@ describe('Converter', () => {
         expect.any(String),
         '# Content with local images'
       );
+    });
+
+    it('should create new ImageProcessor with custom downloadOptions in nested mode', async () => {
+      // Spy on ImageProcessor.prototype.process to verify new instance is called
+      const processSpy = vi.spyOn(ImageProcessor.prototype, 'process')
+        .mockResolvedValue({
+          markdown: '# Test Content',
+          imagesProcessed: 0,
+          imagesDownloaded: 0,
+          imagesSkipped: 0,
+          errors: [],
+        });
+
+      const customOptions = {
+        downloadOptions: {
+          maxRetries: 5,
+          downloadDelayMs: 200,
+        },
+      };
+
+      // Clear the mock to ensure we can track calls
+      vi.mocked(mockImageProcessor.process).mockClear();
+
+      const result = await converter.convertPost(samplePost, '/output', customOptions);
+
+      // When downloadOptions is provided, a new ImageProcessor is created
+      // So the injected mock should NOT be called
+      expect(mockImageProcessor.process).not.toHaveBeenCalled();
+
+      // But the new instance's process method should be called
+      expect(processSpy).toHaveBeenCalled();
+
+      // Verify successful conversion
+      expect(result.success).toBe(true);
+
+      processSpy.mockRestore();
+    });
+  });
+
+  describe('convertPost - Flat Output Mode', () => {
+    it('should use processWithContext in flat mode', async () => {
+      const flatConverter = new Converter({
+        postParser: mockPostParser,
+        markdownTransformer: mockMarkdownTransformer,
+        imageProcessor: mockImageProcessor,
+        frontmatterGenerator: mockFrontmatterGenerator,
+        fileWriter: mockFileWriter,
+        config: { outputStructure: { mode: 'flat' } },
+      });
+
+      await flatConverter.convertPost(samplePost, '/blog/_posts');
+
+      expect(mockImageProcessor.processWithContext).toHaveBeenCalledWith(
+        '# Test Content',
+        expect.objectContaining({
+          imageDir: '/blog/_images',
+          imagePathPrefix: '/images',
+        })
+      );
+      expect(mockImageProcessor.process).not.toHaveBeenCalled();
+    });
+
+    it('should respect custom imageFolderName in flat mode', async () => {
+      const flatConverter = new Converter({
+        postParser: mockPostParser,
+        markdownTransformer: mockMarkdownTransformer,
+        imageProcessor: mockImageProcessor,
+        frontmatterGenerator: mockFrontmatterGenerator,
+        fileWriter: mockFileWriter,
+        config: { outputStructure: { mode: 'flat', imageFolderName: 'assets' } },
+      });
+
+      await flatConverter.convertPost(samplePost, '/src/_posts');
+
+      expect(mockImageProcessor.processWithContext).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          imageDir: '/src/assets',
+          imagePathPrefix: '/images',
+        })
+      );
+    });
+
+    it('should respect custom imagePathPrefix in flat mode', async () => {
+      const flatConverter = new Converter({
+        postParser: mockPostParser,
+        markdownTransformer: mockMarkdownTransformer,
+        imageProcessor: mockImageProcessor,
+        frontmatterGenerator: mockFrontmatterGenerator,
+        fileWriter: mockFileWriter,
+        config: { outputStructure: { mode: 'flat', imagePathPrefix: '/static/img' } },
+      });
+
+      await flatConverter.convertPost(samplePost, '/blog/_posts');
+
+      expect(mockImageProcessor.processWithContext).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          imagePathPrefix: '/static/img',
+        })
+      );
+    });
+
+    it('should create FileWriter with flat mode config', async () => {
+      const flatConverter = new Converter({
+        postParser: mockPostParser,
+        markdownTransformer: mockMarkdownTransformer,
+        imageProcessor: mockImageProcessor,
+        frontmatterGenerator: mockFrontmatterGenerator,
+        fileWriter: mockFileWriter,
+        config: { outputStructure: { mode: 'flat' } },
+      });
+
+      // Mock fs.existsSync to return false for the flat mode file check
+      // (FileWriter checks if {slug}.md exists in flat mode)
+      vi.mocked(fs.existsSync).mockImplementation((path) => {
+        const pathStr = String(path);
+        // Return false for flat mode file path check
+        if (pathStr.includes('test-post.md')) {
+          return false;
+        }
+        // Return true for directory existence checks
+        return true;
+      });
+
+      const result = await flatConverter.convertPost(samplePost, '/blog/_posts');
+
+      // FileWriter configured at construction with flat mode
+      expect(result.success).toBe(true);
+      expect(result.outputPath).toBeTruthy();
+
+      // Restore default mock behavior
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+    });
+
+    it('should use nested mode by default (backward compatibility)', async () => {
+      // No outputStructure option
+      await converter.convertPost(samplePost, '/output');
+
+      expect(mockImageProcessor.process).toHaveBeenCalledWith(
+        '# Test Content',
+        '/output/test-post'
+      );
+      expect(mockImageProcessor.processWithContext).not.toHaveBeenCalled();
+    });
+
+    it('should use nested mode when explicitly specified', async () => {
+      const nestedConverter = new Converter({
+        postParser: mockPostParser,
+        markdownTransformer: mockMarkdownTransformer,
+        imageProcessor: mockImageProcessor,
+        frontmatterGenerator: mockFrontmatterGenerator,
+        fileWriter: mockFileWriter,
+        config: { outputStructure: { mode: 'nested' } },
+      });
+
+      await nestedConverter.convertPost(samplePost, '/output');
+
+      expect(mockImageProcessor.process).toHaveBeenCalledWith(
+        '# Test Content',
+        '/output/test-post'
+      );
+      expect(mockImageProcessor.processWithContext).not.toHaveBeenCalled();
+    });
+
+    it('should handle image directory creation errors in flat mode', async () => {
+      const flatConverter = new Converter({
+        postParser: mockPostParser,
+        markdownTransformer: mockMarkdownTransformer,
+        imageProcessor: mockImageProcessor,
+        frontmatterGenerator: mockFrontmatterGenerator,
+        fileWriter: mockFileWriter,
+        config: { outputStructure: { mode: 'flat' } },
+      });
+
+      // Mock fs.existsSync to return false (directory doesn't exist)
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      // Mock fs.mkdirSync to throw an error
+      vi.mocked(fs.mkdirSync).mockImplementationOnce(() => {
+        throw new Error('Permission denied');
+      });
+
+      const result = await flatConverter.convertPost(samplePost, '/blog/_posts');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Permission denied');
+
+      // Restore fs.mkdirSync to default behavior for other tests
+      vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
+    });
+
+    it('should throw validation error for non-nested outputDir in flat mode', async () => {
+      const flatConverter = new Converter({
+        postParser: mockPostParser,
+        markdownTransformer: mockMarkdownTransformer,
+        imageProcessor: mockImageProcessor,
+        frontmatterGenerator: mockFrontmatterGenerator,
+        fileWriter: mockFileWriter,
+        config: { outputStructure: { mode: 'flat' } },
+      });
+
+      const result = await flatConverter.convertPost(samplePost, '/output');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid outputDir for flat mode');
+      expect(result.error).toContain('nested directory structure');
+    });
+
+    it('should create new ImageProcessor with custom downloadOptions in flat mode', async () => {
+      const flatConverter = new Converter({
+        postParser: mockPostParser,
+        markdownTransformer: mockMarkdownTransformer,
+        imageProcessor: mockImageProcessor,
+        frontmatterGenerator: mockFrontmatterGenerator,
+        fileWriter: mockFileWriter,
+        config: { outputStructure: { mode: 'flat' } },
+      });
+
+      // Spy on ImageProcessor constructor to verify new instance is created
+      const constructorSpy = vi.spyOn(ImageProcessor.prototype, 'processWithContext')
+        .mockResolvedValue({
+          markdown: '# Test Content',
+          imagesProcessed: 0,
+          imagesDownloaded: 0,
+          imagesSkipped: 0,
+          errors: [],
+        });
+
+      const customOptions = {
+        downloadOptions: {
+          maxRetries: 5,
+          downloadDelayMs: 200,
+        },
+      };
+
+      // Clear the mock to ensure we can track calls
+      vi.mocked(mockImageProcessor.processWithContext).mockClear();
+
+      const result = await flatConverter.convertPost(samplePost, '/blog/_posts', customOptions);
+
+      // When downloadOptions is provided, a new ImageProcessor is created
+      // So the injected mock should NOT be called
+      expect(mockImageProcessor.processWithContext).not.toHaveBeenCalled();
+
+      // But the new instance's processWithContext should be called
+      expect(constructorSpy).toHaveBeenCalled();
+
+      // Verify successful conversion
+      expect(result.success).toBe(true);
+
+      constructorSpy.mockRestore();
     });
   });
 

--- a/tests/integration/converter.test.ts
+++ b/tests/integration/converter.test.ts
@@ -8,6 +8,7 @@ import { ImageProcessor } from '../../src/processors/image-processor.js';
 import { FrontmatterGenerator } from '../../src/processors/frontmatter-generator.js';
 import { FileWriter } from '../../src/services/file-writer.js';
 import { Logger } from '../../src/services/logger.js';
+import { Post } from '../../src/models/post.js';
 import type { HashnodePost } from '../../src/types/hashnode-schema.js';
 // Mock fs module
 vi.mock('node:fs');
@@ -282,6 +283,64 @@ describe('Converter', () => {
       expect(mockLogger.info).toHaveBeenCalledWith(
         expect.stringContaining('Skipped')
       );
+    });
+
+    it('should emit skip event with correct nested path', async () => {
+      vi.mocked(mockFileWriter.postExists).mockReturnValue(true);
+      const completedHandler = vi.fn();
+      converter.on('conversion-completed', completedHandler);
+
+      await converter.convertAllPosts('/path/to/export.json', '/output', {
+        skipExisting: true,
+      });
+
+      expect(completedHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          result: expect.objectContaining({
+            slug: 'test-post',
+            outputPath: path.join('/output', 'test-post', 'index.md'),
+            success: true,
+          }),
+        })
+      );
+    });
+
+    it('should fall back to nested format when Post.getFilePath fails', async () => {
+      // NOTE: This tests defensive error handling in getSkipOutputPath().
+      // Post.getFilePath() is mocked to throw, simulating an unexpected error.
+      // This ensures the fallback path works even if Post encounters issues.
+      vi.mocked(mockFileWriter.postExists).mockReturnValue(true);
+
+      const getFilePathSpy = vi.spyOn(Post.prototype, 'getFilePath')
+        .mockImplementationOnce(() => {
+          throw new Error('Simulated getFilePath failure');
+        });
+
+      const completedHandler = vi.fn();
+      converter.on('conversion-completed', completedHandler);
+
+      await converter.convertAllPosts('/path/to/export.json', '/output', {
+        skipExisting: true,
+      });
+
+      // Should log warning about fallback
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to compute skip path for slug "test-post"')
+      );
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Using nested format fallback')
+      );
+
+      // Should fall back to nested format
+      expect(completedHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          result: expect.objectContaining({
+            outputPath: path.join('/output', 'test-post', 'index.md'),
+          }),
+        })
+      );
+
+      getFilePathSpy.mockRestore();
     });
   });
 
@@ -969,6 +1028,36 @@ describe('Converter', () => {
       expect(result.success).toBe(true);
 
       constructorSpy.mockRestore();
+    });
+
+    it('should emit skip event with correct flat path when post exists', async () => {
+      const flatConverter = new Converter({
+        postParser: mockPostParser,
+        markdownTransformer: mockMarkdownTransformer,
+        imageProcessor: mockImageProcessor,
+        frontmatterGenerator: mockFrontmatterGenerator,
+        fileWriter: mockFileWriter,
+        logger: mockLogger,
+        config: { outputStructure: { mode: 'flat' } },
+      });
+
+      vi.mocked(mockFileWriter.postExists).mockReturnValue(true);
+      const completedHandler = vi.fn();
+      flatConverter.on('conversion-completed', completedHandler);
+
+      await flatConverter.convertAllPosts('/path/to/export.json', '/blog/_posts', {
+        skipExisting: true,
+      });
+
+      expect(completedHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          result: expect.objectContaining({
+            slug: 'test-post',
+            outputPath: path.join('/blog/_posts', 'test-post.md'),
+            success: true,
+          }),
+        })
+      );
     });
   });
 

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -10,11 +10,15 @@ import {
   validateLogFilePath,
   validateMutuallyExclusiveFlags,
   validateOptions,
+  validateImageFolder,
+  validateImagePrefix,
   createProgressBar,
   createProgressCallback,
   displayResult,
   program,
+  runConvert,
 } from '../../src/cli/convert.js';
+import { Converter } from '../../src/converter.js';
 import type { ConversionResult } from '../../src/types/conversion-result.js';
 
 // Mock fs module
@@ -520,6 +524,237 @@ describe('CLI', () => {
       expect(convertCmd).toBeDefined();
       const option = convertCmd!.options.find(opt => opt.long === '--image-prefix');
       expect(option).toBeDefined();
+    });
+  });
+
+  // ===========================================================================
+  // validateImageFolder Tests
+  // ===========================================================================
+  describe('validateImageFolder', () => {
+    it('should accept valid relative folder names', () => {
+      expect(() => validateImageFolder('_images')).not.toThrow();
+      expect(() => validateImageFolder('assets')).not.toThrow();
+      expect(() => validateImageFolder('static/img')).not.toThrow();
+    });
+
+    it('should accept hyphenated and underscored names', () => {
+      expect(() => validateImageFolder('my-images')).not.toThrow();
+      expect(() => validateImageFolder('my_images')).not.toThrow();
+    });
+
+    it('should reject absolute paths', () => {
+      expect(() => validateImageFolder('/etc/passwd'))
+        .toThrow('Must be a relative path');
+      expect(() => validateImageFolder('/var/www/images'))
+        .toThrow('Must be a relative path');
+    });
+
+    it('should reject path traversal attempts', () => {
+      expect(() => validateImageFolder('../etc'))
+        .toThrow('Path traversal (..) is not allowed');
+      expect(() => validateImageFolder('images/../../../etc'))
+        .toThrow('Path traversal (..) is not allowed');
+    });
+
+    it('should reject shell metacharacters', () => {
+      expect(() => validateImageFolder('img<script>'))
+        .toThrow('Contains invalid filesystem characters');
+      expect(() => validateImageFolder('img|rm'))
+        .toThrow('Contains invalid filesystem characters');
+      expect(() => validateImageFolder('img*'))
+        .toThrow('Contains invalid filesystem characters');
+    });
+
+    it('should reject empty folder names', () => {
+      expect(() => validateImageFolder(''))
+        .toThrow('folder name cannot be empty');
+      expect(() => validateImageFolder('   '))
+        .toThrow('folder name cannot be empty');
+    });
+
+    it('should reject names with control characters', () => {
+      expect(() => validateImageFolder('img\x00name'))
+        .toThrow('Contains invalid filesystem characters');
+    });
+  });
+
+  // ===========================================================================
+  // validateImagePrefix Tests
+  // ===========================================================================
+  describe('validateImagePrefix', () => {
+    it('should accept valid prefixes starting with /', () => {
+      expect(() => validateImagePrefix('/images')).not.toThrow();
+      expect(() => validateImagePrefix('/assets/img')).not.toThrow();
+      expect(() => validateImagePrefix('/static')).not.toThrow();
+    });
+
+    it('should accept nested path prefixes', () => {
+      expect(() => validateImagePrefix('/assets/images/blog')).not.toThrow();
+    });
+
+    it('should reject prefixes not starting with /', () => {
+      expect(() => validateImagePrefix('images'))
+        .toThrow('Must start with "/"');
+      expect(() => validateImagePrefix('assets/images'))
+        .toThrow('Must start with "/"');
+    });
+
+    it('should reject characters outside the allowlist', () => {
+      expect(() => validateImagePrefix('/img<script>'))
+        .toThrow('Only alphanumeric characters');
+      expect(() => validateImagePrefix('/img"onclick'))
+        .toThrow('Only alphanumeric characters');
+      expect(() => validateImagePrefix("/img'alert"))
+        .toThrow('Only alphanumeric characters');
+    });
+
+    it('should reject ) which breaks markdown link destinations', () => {
+      expect(() => validateImagePrefix('/images)'))
+        .toThrow('Only alphanumeric characters');
+    });
+
+    it('should reject whitespace and control characters', () => {
+      expect(() => validateImagePrefix('/my images'))
+        .toThrow('Only alphanumeric characters');
+      expect(() => validateImagePrefix('/images\t'))
+        .toThrow('Only alphanumeric characters');
+      expect(() => validateImagePrefix('/images\n'))
+        .toThrow('Only alphanumeric characters');
+    });
+
+    it('should reject prefix that is just "/"', () => {
+      expect(() => validateImagePrefix('/'))
+        .toThrow('Only alphanumeric characters');
+    });
+  });
+
+  // ===========================================================================
+  // runConvert Flat Mode Wiring Tests
+  // ===========================================================================
+  describe('runConvert flat mode wiring', () => {
+    let mockConvertAllPosts: ReturnType<typeof vi.fn>;
+    let withProgressSpy: ReturnType<typeof vi.spyOn>;
+    let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+    let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+    let stdoutSpy: ReturnType<typeof vi.spyOn>;
+    let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+    const baseOptions = {
+      export: './export.json',
+      output: './output',
+      skipExisting: true,
+      verbose: false,
+      quiet: true,
+      flat: false,
+    };
+
+    beforeEach(() => {
+      // Mock filesystem for validateOptions
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.statSync).mockReturnValue({ isFile: () => true } as fs.Stats);
+      vi.mocked(fs.readFileSync).mockReturnValue('{"posts": []}');
+
+      // Mock console output
+      consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+      // Mock process.exit to prevent test termination
+      processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+      // Mock Converter.withProgress to capture deps
+      mockConvertAllPosts = vi.fn().mockResolvedValue({
+        converted: 1,
+        skipped: 0,
+        errors: [],
+        duration: '1s',
+      });
+      withProgressSpy = vi.spyOn(Converter, 'withProgress').mockReturnValue({
+        convertAllPosts: mockConvertAllPosts,
+      } as unknown as Converter);
+    });
+
+    afterEach(() => {
+      consoleWarnSpy.mockRestore();
+      consoleLogSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      processExitSpy.mockRestore();
+      withProgressSpy.mockRestore();
+    });
+
+    it('should warn when --image-folder is used without --flat', async () => {
+      await runConvert({ ...baseOptions, imageFolder: 'assets' });
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Warning: --image-folder is ignored without --flat'
+      );
+    });
+
+    it('should warn when --image-prefix is used without --flat', async () => {
+      await runConvert({ ...baseOptions, imagePrefix: '/static' });
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Warning: --image-prefix is ignored without --flat'
+      );
+    });
+
+    it('should not warn when flat-only options are used with --flat', async () => {
+      await runConvert({
+        ...baseOptions,
+        flat: true,
+        imageFolder: 'assets',
+        imagePrefix: '/static',
+      });
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('should pass outputStructure config to Converter.withProgress in flat mode', async () => {
+      await runConvert({ ...baseOptions, flat: true });
+
+      expect(withProgressSpy).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({
+          config: {
+            outputStructure: {
+              mode: 'flat',
+              imageFolderName: undefined,
+              imagePathPrefix: undefined,
+            },
+          },
+        })
+      );
+    });
+
+    it('should pass custom imageFolder and imagePrefix in flat mode config', async () => {
+      await runConvert({
+        ...baseOptions,
+        flat: true,
+        imageFolder: 'assets',
+        imagePrefix: '/static',
+      });
+
+      expect(withProgressSpy).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({
+          config: {
+            outputStructure: {
+              mode: 'flat',
+              imageFolderName: 'assets',
+              imagePathPrefix: '/static',
+            },
+          },
+        })
+      );
+    });
+
+    it('should not pass converter deps in nested mode', async () => {
+      await runConvert(baseOptions);
+
+      expect(withProgressSpy).toHaveBeenCalledWith(
+        expect.any(Function),
+        undefined
+      );
     });
   });
 });

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -13,6 +13,7 @@ import {
   createProgressBar,
   createProgressCallback,
   displayResult,
+  program,
 } from '../../src/cli/convert.js';
 import type { ConversionResult } from '../../src/types/conversion-result.js';
 
@@ -492,6 +493,33 @@ describe('CLI', () => {
         call => typeof call[0] === 'string' && call[0].includes('\r')
       );
       expect(clearCalls.length).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // Flat Mode CLI Flag Registration Tests
+  // ===========================================================================
+  describe('Flat mode CLI flags', () => {
+    it('should register --flat flag with short alias -f on convert command', () => {
+      const convertCmd = program.commands.find(cmd => cmd.name() === 'convert');
+      expect(convertCmd).toBeDefined();
+      const flatOption = convertCmd!.options.find(opt => opt.long === '--flat');
+      expect(flatOption).toBeDefined();
+      expect(flatOption!.short).toBe('-f');
+    });
+
+    it('should register --image-folder option on convert command', () => {
+      const convertCmd = program.commands.find(cmd => cmd.name() === 'convert');
+      expect(convertCmd).toBeDefined();
+      const option = convertCmd!.options.find(opt => opt.long === '--image-folder');
+      expect(option).toBeDefined();
+    });
+
+    it('should register --image-prefix option on convert command', () => {
+      const convertCmd = program.commands.find(cmd => cmd.name() === 'convert');
+      expect(convertCmd).toBeDefined();
+      const option = convertCmd!.options.find(opt => opt.long === '--image-prefix');
+      expect(option).toBeDefined();
     });
   });
 });

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -756,5 +756,49 @@ describe('CLI', () => {
         undefined
       );
     });
+
+    // =========================================================================
+    // Startup Display: Mode line
+    // =========================================================================
+    describe('startup display Mode line', () => {
+      it('should display nested mode when flat is false', async () => {
+        await runConvert({ ...baseOptions, quiet: false, flat: false });
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          'Mode:    nested ({slug}/index.md)'
+        );
+      });
+
+      it('should display flat mode with default image folder', async () => {
+        await runConvert({ ...baseOptions, quiet: false, flat: true });
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          'Mode:    flat (images -> ../_images/)'
+        );
+      });
+
+      it('should display flat mode with custom image folder', async () => {
+        await runConvert({
+          ...baseOptions,
+          quiet: false,
+          flat: true,
+          imageFolder: 'assets',
+        });
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          'Mode:    flat (images -> ../assets/)'
+        );
+      });
+
+      it('should not display Mode line when quiet flag is enabled', async () => {
+        await runConvert({ ...baseOptions, quiet: true, flat: true });
+
+        const logCalls = consoleLogSpy.mock.calls.map(call => call[0]);
+        const hasModeCall = logCalls.some(
+          (arg: unknown) => typeof arg === 'string' && (arg as string).startsWith('Mode:')
+        );
+        expect(hasModeCall).toBe(false);
+      });
+    });
   });
 });

--- a/tests/unit/file-writer.test.ts
+++ b/tests/unit/file-writer.test.ts
@@ -418,4 +418,40 @@ describe('FileWriter', () => {
       }
     });
   });
+
+  describe('outputMode Configuration', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.promises.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined);
+      vi.mocked(fs.promises.rename).mockResolvedValue(undefined);
+    });
+
+    it('should default outputMode to nested when not provided', async () => {
+      const writer = new FileWriter();
+      const result = await writer.writePost('./blog', 'my-post', '---\n', 'content');
+      // Verify nested behavior (creates {slug}/index.md)
+      expect(result).toContain('my-post/index.md');
+    });
+
+    it('should accept nested outputMode explicitly', async () => {
+      const writer = new FileWriter({ outputMode: 'nested' });
+      const result = await writer.writePost('./blog', 'my-post', '---\n', 'content');
+      expect(result).toContain('my-post/index.md');
+    });
+
+    it('should accept flat outputMode', () => {
+      // For now, just verify the config is accepted without error
+      // Actual flat behavior will be tested in Step 2.3
+      const writer = new FileWriter({ outputMode: 'flat' });
+      expect(writer).toBeInstanceOf(FileWriter);
+    });
+
+    it('should use default values when config is undefined', async () => {
+      const writer = new FileWriter(undefined);
+      const result = await writer.writePost('./blog', 'my-post', '---\n', 'content');
+      expect(result).toContain('my-post/index.md');
+    });
+  });
 });

--- a/tests/unit/models/post.test.ts
+++ b/tests/unit/models/post.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from 'vitest';
+import { Post, PostValidationError } from '../../../src/models/post.js';
+
+describe('Post', () => {
+  describe('constructor', () => {
+    it('should create a post with required properties', () => {
+      const post = new Post({
+        slug: 'my-post',
+        frontmatter: '---\ntitle: Test\n---',
+        content: '# Hello',
+      });
+
+      expect(post.slug).toBe('my-post');
+      expect(post.frontmatter).toBe('---\ntitle: Test\n---');
+      expect(post.content).toBe('# Hello');
+    });
+
+    it('should default outputMode to nested', () => {
+      const post = new Post({
+        slug: 'my-post',
+        frontmatter: '---\n---',
+        content: '',
+      });
+
+      expect(post.outputMode).toBe('nested');
+    });
+
+    it('should accept flat outputMode', () => {
+      const post = new Post({
+        slug: 'my-post',
+        frontmatter: '---\n---',
+        content: '',
+        outputMode: 'flat',
+      });
+
+      expect(post.outputMode).toBe('flat');
+    });
+
+    it('should accept nested outputMode explicitly', () => {
+      const post = new Post({
+        slug: 'my-post',
+        frontmatter: '---\n---',
+        content: '',
+        outputMode: 'nested',
+      });
+
+      expect(post.outputMode).toBe('nested');
+    });
+  });
+
+  describe('getFilePath', () => {
+    it('should return {slug}/index.md in nested mode', () => {
+      const post = new Post({
+        slug: 'my-post',
+        frontmatter: '---\n---',
+        content: '',
+        outputMode: 'nested',
+      });
+
+      const filePath = post.getFilePath('./blog');
+
+      expect(filePath).toBe('blog/my-post/index.md');
+    });
+
+    it('should return {slug}.md in flat mode', () => {
+      const post = new Post({
+        slug: 'my-post',
+        frontmatter: '---\n---',
+        content: '',
+        outputMode: 'flat',
+      });
+
+      const filePath = post.getFilePath('./blog');
+
+      expect(filePath).toBe('blog/my-post.md');
+    });
+
+    it('should handle absolute output directory in nested mode', () => {
+      const post = new Post({
+        slug: 'test-post',
+        frontmatter: '---\n---',
+        content: '',
+        outputMode: 'nested',
+      });
+
+      const filePath = post.getFilePath('/home/user/blog');
+
+      expect(filePath).toBe('/home/user/blog/test-post/index.md');
+    });
+
+    it('should handle absolute output directory in flat mode', () => {
+      const post = new Post({
+        slug: 'test-post',
+        frontmatter: '---\n---',
+        content: '',
+        outputMode: 'flat',
+      });
+
+      const filePath = post.getFilePath('/home/user/blog');
+
+      expect(filePath).toBe('/home/user/blog/test-post.md');
+    });
+  });
+
+  describe('getDirectoryPath', () => {
+    it('should return outputDir/slug in nested mode', () => {
+      const post = new Post({
+        slug: 'my-post',
+        frontmatter: '---\n---',
+        content: '',
+        outputMode: 'nested',
+      });
+
+      const dirPath = post.getDirectoryPath('./blog');
+
+      expect(dirPath).toBe('blog/my-post');
+    });
+
+    it('should return outputDir in flat mode', () => {
+      const post = new Post({
+        slug: 'my-post',
+        frontmatter: '---\n---',
+        content: '',
+        outputMode: 'flat',
+      });
+
+      const dirPath = post.getDirectoryPath('./blog');
+
+      expect(dirPath).toBe('./blog');
+    });
+  });
+
+  describe('getMarkdown', () => {
+    it('should combine frontmatter and content with newline', () => {
+      const post = new Post({
+        slug: 'my-post',
+        frontmatter: '---\ntitle: Test\n---',
+        content: '# Hello World',
+      });
+
+      const markdown = post.getMarkdown();
+
+      expect(markdown).toBe('---\ntitle: Test\n---\n# Hello World');
+    });
+
+    it('should handle empty content', () => {
+      const post = new Post({
+        slug: 'my-post',
+        frontmatter: '---\ntitle: Test\n---',
+        content: '',
+      });
+
+      const markdown = post.getMarkdown();
+
+      expect(markdown).toBe('---\ntitle: Test\n---\n');
+    });
+
+    it('should handle empty frontmatter', () => {
+      const post = new Post({
+        slug: 'my-post',
+        frontmatter: '',
+        content: '# Hello',
+      });
+
+      const markdown = post.getMarkdown();
+
+      expect(markdown).toBe('\n# Hello');
+    });
+  });
+
+  describe('getExistencePath', () => {
+    it('should return directory path in nested mode', () => {
+      const post = new Post({
+        slug: 'my-post',
+        frontmatter: '---\n---',
+        content: '',
+        outputMode: 'nested',
+      });
+
+      const existPath = post.getExistencePath('./blog');
+
+      expect(existPath).toBe('blog/my-post');
+    });
+
+    it('should return file path in flat mode', () => {
+      const post = new Post({
+        slug: 'my-post',
+        frontmatter: '---\n---',
+        content: '',
+        outputMode: 'flat',
+      });
+
+      const existPath = post.getExistencePath('./blog');
+
+      expect(existPath).toBe('blog/my-post.md');
+    });
+  });
+
+  describe('slug sanitization', () => {
+    it('should trim whitespace from slug', () => {
+      const post = new Post({
+        slug: '  my-post  ',
+        frontmatter: '---\n---',
+        content: '',
+      });
+
+      expect(post.slug).toBe('my-post');
+    });
+
+    it('should replace invalid characters with hyphens', () => {
+      const post = new Post({
+        slug: 'my:post*with?chars',
+        frontmatter: '---\n---',
+        content: '',
+      });
+
+      expect(post.slug).toBe('my-post-with-chars');
+    });
+
+    it('should handle unicode characters', () => {
+      const post = new Post({
+        slug: '日本語',
+        frontmatter: '---\n---',
+        content: '',
+      });
+
+      expect(post.slug).toBe('日本語');
+    });
+
+    it('should throw PostValidationError for absolute paths', () => {
+      expect(() => {
+        new Post({
+          slug: '/etc/passwd',
+          frontmatter: '---\n---',
+          content: '',
+        });
+      }).toThrow(new PostValidationError('Invalid slug: absolute paths are not allowed (/etc/passwd)', '/etc/passwd'));
+    });
+
+    it('should throw PostValidationError for parent directory traversal', () => {
+      expect(() => {
+        new Post({
+          slug: '../etc/passwd',
+          frontmatter: '---\n---',
+          content: '',
+        });
+      }).toThrow(new PostValidationError('Invalid slug: parent directory traversal is not allowed (../etc/passwd)', '../etc/passwd'));
+    });
+
+    it('should throw PostValidationError for empty slug after sanitization', () => {
+      expect(() => {
+        new Post({
+          slug: '   ',
+          frontmatter: '---\n---',
+          content: '',
+        });
+      }).toThrow(new PostValidationError('Invalid slug: slug is empty after sanitization (original:    )', '   '));
+    });
+
+    it('should include original slug in error', () => {
+      try {
+        new Post({
+          slug: '/invalid/path',
+          frontmatter: '---\n---',
+          content: '',
+        });
+      } catch (error) {
+        expect(error).toBeInstanceOf(PostValidationError);
+        expect((error as PostValidationError).slug).toBe('/invalid/path');
+      }
+    });
+  });
+
+  describe('immutability', () => {
+    it('should have readonly properties', () => {
+      const post = new Post({
+        slug: 'my-post',
+        frontmatter: '---\n---',
+        content: '# Hello',
+        outputMode: 'flat',
+      });
+
+      // TypeScript enforces readonly, but verify values don't change
+      expect(post.slug).toBe('my-post');
+      expect(post.frontmatter).toBe('---\n---');
+      expect(post.content).toBe('# Hello');
+      expect(post.outputMode).toBe('flat');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add a `--flat` CLI flag that enables an alternative flat output mode for compatibility with static site generators like Bridgetown, Jekyll, and Hugo.

**Current (nested) mode:**
```
output/
├── post-slug-1/
│   ├── index.md
│   └── image.png
```

**New flat mode (`--flat`):**
```
output/
├── _posts/
│   └── post-slug-1.md
└── _images/
    └── image.png
```

## Implementation Progress

### Phase 1: Type Definitions
- [x] Step 1.1: Add OutputStructure interface (#72)
- [x] Step 1.2: Add ImageProcessorContext interface

### Phase 2: FileWriter Service Updates
- [x] Step 2.1: Add outputMode configuration
- [x] Step 2.2: Update postExists method
- [x] Step 2.3: Update writePost method
- [x] Step 2.4: Write FileWriter unit tests

### Phase 3: ImageProcessor Updates
- [x] Step 3.1: Add processWithContext method
- [x] Step 3.2: Write ImageProcessor unit tests

### Phase 4: Converter Updates
- [x] Step 4.1: Update convertPost method
- [x] Step 4.2: Update convertAllPosts method
- [x] Step 4.3: Write Converter integration tests

### Phase 5: CLI Updates
- [x] Step 5.1: Update CLIOptions interface
- [x] Step 5.2: Add CLI flags
- [x] Step 5.3: Build outputStructure from CLI options
- [x] Step 5.4: Update startup display
- [x] Step 5.5: Write CLI unit tests

### Phase 6: Documentation
- [x] Step 6.1: Update public exports
- [x] Step 6.2: Update README
- [ ] Step 6.3: Update CHANGELOG

## Related

- Implementation plan: [docs/IMPLEMENTATION_FLAT.md](docs/IMPLEMENTATION_FLAT.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)