### PR TITLE
Fix CLI entry point detection when invoked via symlink

### DIFF
--- a/src/cli/convert.ts
+++ b/src/cli/convert.ts
@@ -467,7 +467,20 @@ export type { CLIOptions, ValidatedOptions };
 
 // Parse arguments and execute only when run directly (not imported)
 // ESM equivalent of require.main === module
-const isMainModule = process.argv[1] === fileURLToPath(import.meta.url);
-if (isMainModule) {
+// Use fs.realpathSync to resolve symlinks (e.g., npm link creates symlinked binaries)
+function checkIsMainModule(): boolean {
+  try {
+    const argv1 = fs.realpathSync(process.argv[1]);
+    const thisFile = fs.realpathSync(fileURLToPath(import.meta.url));
+    // Guard against mocked fs returning undefined in test environments
+    if (!argv1 || !thisFile) return false;
+    return argv1 === thisFile;
+  } catch {
+    // Fallback to direct comparison if realpathSync fails
+    return process.argv[1] === fileURLToPath(import.meta.url);
+  }
+}
+
+if (checkIsMainModule()) {
   program.parse();
 }


### PR DESCRIPTION
## Summary
- Replaces direct `process.argv[1]` comparison with `fs.realpathSync`-based resolution to handle symlinked binaries
- Fixes the CLI not executing when installed globally or via `npm link`, where the binary path is a symlink pointing to the actual script
- Includes a try/catch fallback to the original comparison if `realpathSync` fails, and a guard against mocked `fs` returning undefined in tests

## Test plan
- [x] Run `npm link` locally and verify `hashnode-converter convert --help` works
- [x] Run existing CLI tests with `npm test` to ensure no regressions
- [x] Verify `npm run type-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)